### PR TITLE
refactor: proper menu handling

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 use clap::{ArgGroup, Parser};
 use crossterm::cursor::SetCursorStyle;
 
-use crate::constants::{DEFAULT_LANGUAGE, DEFAULT_THEME};
+use crate::constants::{DEFAULT_CURSOR_STYLE, DEFAULT_LANGUAGE, DEFAULT_THEME};
 
 #[derive(Parser, Debug, Clone)]
 #[command(name = "Termitype", about = "Terminal based typing game")]
@@ -107,7 +107,7 @@ impl Default for Config {
             use_numbers: false,
             use_punctuation: false,
             theme: Some(DEFAULT_THEME.to_string()),
-            cursor_style: None,
+            cursor_style: Some(DEFAULT_CURSOR_STYLE.to_string()),
             color_mode: None,
             list_themes: false,
             version: false,
@@ -164,6 +164,11 @@ impl Config {
     /// Chages the current theme of the game.
     pub fn change_theme(&mut self, theme_name: &str) {
         self.theme = Some(theme_name.to_string())
+    }
+
+    /// Chages the current style of the cursor.
+    pub fn change_cursor_style(&mut self, style: &str) {
+        self.cursor_style = Some(style.to_string())
     }
 
     /// Resets the words flag after a test has been run with it.
@@ -266,6 +271,7 @@ mod tests {
         let config = Config::default();
         assert!(config.language.is_some());
         assert!(config.time.is_some());
+        assert!(config.theme.is_some());
         assert!(config.word_count.is_none());
         assert_eq!(config.language, Some(DEFAULT_LANGUAGE.to_string()));
         assert_eq!(config.use_symbols, false);

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,5 +1,6 @@
 pub const APPNAME: &str = "termitype";
 pub const DEFAULT_LANGUAGE: &str = "english";
+pub const DEFAULT_CURSOR_STYLE: &str = "beam";
 pub const DEFAULT_THEME: &str = "tokyonight";
 
 pub const AMOUNT_OF_VISIBLE_LINES: u8 = 3;

--- a/src/input.rs
+++ b/src/input.rs
@@ -180,7 +180,7 @@ impl InputProcessor for Termi {
     }
 
     fn handle_menu_select(&mut self) -> Action {
-        if let Some(action) = self.menu.enter() {
+        if let Some(action) = self.menu.enter(&self.config) {
             match action {
                 MenuAction::Restart => {
                     self.start();
@@ -214,8 +214,8 @@ impl InputProcessor for Termi {
                     self.config.change_theme(&theme_name);
                     self.theme = Theme::from_name(&theme_name);
                 }
-                MenuAction::ChangeCursorStyle(steyl) => {
-                    self.config.cursor_style = Some(steyl);
+                MenuAction::ChangeCursorStyle(style) => {
+                    self.config.change_cursor_style(&style);
                     execute!(
                         std::io::stdout(),
                         self.config.resolve_current_cursor_style()

--- a/src/termi.rs
+++ b/src/termi.rs
@@ -68,7 +68,7 @@ impl Termi {
             preview_cursor: None,
             builder,
             words,
-            menu: MenuState::default(),
+            menu: MenuState::new(),
             clickable_regions: Vec::new(),
         }
     }
@@ -104,6 +104,7 @@ impl Termi {
                         self.menu.toggle(&self.config);
                         self.menu.execute(MenuAction::OpenThemePicker, &self.config);
                         self.menu.preview_selected();
+                        self.update_preview_theme();
                     }
                     ClickAction::OpenLanguagePicker => {
                         self.menu.toggle(&self.config);

--- a/src/ui/components.rs
+++ b/src/ui/components.rs
@@ -500,9 +500,7 @@ pub fn command_bar(f: &mut Frame, termi: &Termi, area: Rect) {
     f.render_widget(Paragraph::new(lines).alignment(Alignment::Center), area);
 }
 
-pub fn footer(f: &mut Frame, termi: &Termi, area: Rect) -> Vec<ClickableRegion> {
-    let mut regions = Vec::new();
-
+pub fn footer(f: &mut Frame, termi: &mut Termi, area: Rect) {
     let elements = vec![
         UIElement::new(" ", false, None),
         UIElement::new("github.com/emanuel2718/termitype", false, None),
@@ -530,7 +528,7 @@ pub fn footer(f: &mut Frame, termi: &Termi, area: Rect) -> Vec<ClickableRegion> 
             let span = element.to_span(&termi.theme);
 
             if let Some(action) = &element.action {
-                regions.push(ClickableRegion {
+                termi.clickable_regions.push(ClickableRegion {
                     area: Rect {
                         x: current_x,
                         y: area.y,
@@ -550,11 +548,9 @@ pub fn footer(f: &mut Frame, termi: &Termi, area: Rect) -> Vec<ClickableRegion> 
         Paragraph::new(Line::from(spans)).alignment(Alignment::Center),
         area,
     );
-
-    regions
 }
 
-pub fn results_screen(f: &mut Frame, termi: &Termi, area: Rect) {
+pub fn results_screen(f: &mut Frame, termi: &mut Termi, area: Rect) {
     let layout = Layout::default()
         .direction(Direction::Vertical)
         .constraints([

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -54,8 +54,7 @@ pub fn draw_ui(f: &mut Frame, termi: &mut Termi) {
             progress_info(f, termi, typing_chunks[0]);
             typing_area(f, termi, typing_chunks[2]);
             command_bar(f, termi, layout[3]);
-            let footer_regions = footer(f, termi, layout[4]);
-            termi.clickable_regions.extend(footer_regions);
+            footer(f, termi, layout[4]);
         }
     }
     if termi.menu.is_open() {


### PR DESCRIPTION
Migrate from the old, annoying way, of selecting menu items by guessing their index position.

Before, if we wanted to open the `ThemePicker` programmatically we would have to know the index position of the `ThemePicker` entry and do `self.menu.select(5)` (assuming the ThemePicker was the 5th entry in the menu, which could change thus the annoying part of this).

Now, we do `self.menu.execute(MenuAction::OpenThemePicker, &self.config);`, which is more verbose but favors my sanity.

The `execute` also handles any given `MenuAction`, which is handy.

This enable opening the `ThemePicker` and the `LanguagePicker` straight from the UI witch click actions without worrying about their index positions.