### PR TITLE
fix: start over with menu toggles

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -286,6 +286,7 @@ impl InputProcessor for Termi {
                         _ => {}
                     }
                     self.menu.update_toggles(&self.config);
+                    self.start();
                 }
                 MenuAction::ChangeMode(mode) => {
                     self.config.change_mode(mode, None);


### PR DESCRIPTION
Toggle in the menu were not causing a restart