### PR TITLE
fix: correctly load langugage pack using assets.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1079,7 +1079,7 @@ dependencies = [
 
 [[package]]
 name = "termitype"
-version = "0.0.1-alpha.3"
+version = "0.0.1-alpha.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "termitype"
 build = "build.rs"
 description = "Terminal-based typing test inspired by monkeytype"
-version = "0.0.1-alpha.3"
+version = "0.0.1-alpha.4"
 license = "MIT"
 categories = ["command-line-utilities", "games"]
 keywords = ["tui", "cli", "typing", "game"]

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -5,14 +5,13 @@ use include_dir::{include_dir, Dir};
 pub static ASSETS: Dir = include_dir!("assets");
 
 pub fn get_theme(name: &str) -> Option<String> {
-    let path = format!("themes/{}", name);
-    let result = ASSETS.get_file(&path);
+    let result = ASSETS.get_file(format!("themes/{}", name));
     result.map(|f| f.contents_utf8().unwrap_or_default().to_string())
 }
 
 pub fn get_language(name: &str) -> Option<String> {
     ASSETS
-        .get_file(format!("languages/{}", name))
+        .get_file(format!("languages/{}.json", name))
         .map(|f| f.contents_utf8().unwrap_or_default().to_string())
 }
 
@@ -48,10 +47,11 @@ pub fn list_languages() -> Vec<String> {
                 .filter(|f| f.path().extension().is_some_and(|ext| ext == "json"))
                 .filter_map(|f| {
                     f.path()
-                        .file_name()
+                        .file_stem()
                         .and_then(|n| n.to_str())
                         .map(String::from)
                 })
+                .filter(|name| name != "_list")
                 .collect()
         })
         .unwrap_or_default()

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -95,7 +95,7 @@ impl Builder {
     /// Returns the list of available languages.
     pub fn available_languages() -> &'static [String] {
         static LANGUAGES: OnceLock<Vec<String>> = OnceLock::new();
-        LANGUAGES.get_or_init(|| assets::list_languages())
+        LANGUAGES.get_or_init(assets::list_languages)
     }
 
     /// Checks if the given language is available.

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,1 +1,1 @@
-pub static VERSION: &str = "v0.0.1-alpha.3";
+pub static VERSION: &str = "v0.0.1-alpha.4";


### PR DESCRIPTION
Before we were loading the language pack using the filesystem.
This was wrong but I didn't noticed the problem as I was executing
the `termitype` binary from the root of the repo everytime and
everything seem to be working fine. It wasn't until I downloaded the
package from crates.io on another computer (which didn't had the repo)
that I found to cause of the missing language pack on installed
binaries.

Relates to: #31