### PR TITLE
feat: quake menu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "termitype"
-version = "0.0.1-alpha.17"
+version = "0.0.1-alpha.18"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "termitype"
 build = "build.rs"
 description = "Terminal-based typing test inspired by monkeytype"
-version = "0.0.1-alpha.17"
+version = "0.0.1-alpha.18"
 license = "MIT"
 categories = ["command-line-utilities", "games"]
 keywords = ["tui", "cli", "typing", "game"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,7 @@ ureq = "3.0.8"
 flate2 = "1.1.0"
 tar = "0.4.44"
 sha2 = "0.10.8"
+
+[[bench]]
+name = "theme_benchmarks"
+harness = false

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ cargo run -- --debug
 ## Installation
 
 ```sh
-cargo install termitype@0.0.1-alpha.15
+cargo install termitype@0.0.1-alpha.18
 ```
 
 ### TODO

--- a/benches/theme_benchmarks.rs
+++ b/benches/theme_benchmarks.rs
@@ -1,0 +1,123 @@
+use std::time::{Duration, Instant};
+use termitype::{config::Config, theme::Theme};
+
+struct BenchmarkStats {
+    min: Duration,
+    max: Duration,
+    mean: Duration,
+    median: Duration,
+    p95: Duration,
+    samples: Vec<Duration>,
+}
+
+impl BenchmarkStats {
+    fn new(mut samples: Vec<Duration>) -> Self {
+        samples.sort();
+        let len = samples.len();
+        let mean = samples.iter().sum::<Duration>() / len as u32;
+        let median = samples[len / 2];
+        let p95 = samples[(len as f64 * 0.95) as usize];
+        let min = samples[0];
+        let max = samples[len - 1];
+
+        Self {
+            min,
+            max,
+            mean,
+            median,
+            p95,
+            samples,
+        }
+    }
+
+    fn report(&self, name: &str) {
+        eprintln!("\nBenchmark Results for {}", name);
+        eprintln!("---------------------------");
+        eprintln!("Min:    {:?}", self.min);
+        eprintln!("Max:    {:?}", self.max);
+        eprintln!("Mean:   {:?}", self.mean);
+        eprintln!("Median: {:?}", self.median);
+        eprintln!("P95:    {:?}", self.p95);
+
+        let mean_nanos = self.mean.as_nanos() as f64;
+        let variance: f64 = self
+            .samples
+            .iter()
+            .map(|&d| {
+                let diff = d.as_nanos() as f64 - mean_nanos;
+                diff * diff
+            })
+            .sum::<f64>()
+            / self.samples.len() as f64;
+        let std_dev = Duration::from_nanos(variance.sqrt() as u64);
+        eprintln!("StdDev: {:?}", std_dev);
+    }
+}
+
+fn main() {
+    let _ = Theme::new(&Config::default());
+    let themes = termitype::theme::available_themes();
+
+    benchmark_theme_switching(themes);
+
+    benchmark_theme_rapid_switching(themes);
+}
+
+fn benchmark_theme_switching(themes: &[String]) {
+    const WARMUP_ITERATIONS: usize = 100;
+    const MEASURE_ITERATIONS: usize = 1000;
+
+    eprintln!("\nWarming up...");
+    for theme_name in themes.iter().cycle().take(WARMUP_ITERATIONS) {
+        let _ = Theme::from_name(theme_name);
+    }
+
+    eprintln!("Collecting measurements...");
+    let mut measurements = Vec::with_capacity(MEASURE_ITERATIONS);
+
+    for theme_name in themes.iter().cycle().take(MEASURE_ITERATIONS) {
+        std::thread::sleep(Duration::from_micros(10));
+
+        let start = Instant::now();
+        let _ = Theme::from_name(theme_name);
+        measurements.push(start.elapsed());
+    }
+
+    let stats = BenchmarkStats::new(measurements);
+    stats.report("Theme Switching");
+
+    assert!(
+        stats.p95 < Duration::from_micros(500),
+        "95th percentile theme switching time ({:?}) exceeded 500µs threshold",
+        stats.p95
+    );
+}
+
+fn benchmark_theme_rapid_switching(themes: &[String]) {
+    const BURST_SIZE: usize = 100;
+    const NUM_BURSTS: usize = 50;
+
+    let mut burst_times = Vec::with_capacity(NUM_BURSTS);
+
+    eprintln!("\nMeasuring rapid theme switching in bursts...");
+    for i in 0..NUM_BURSTS {
+        if i > 0 {
+            std::thread::sleep(Duration::from_millis(100));
+        }
+
+        let start = Instant::now();
+        for theme_name in themes.iter().cycle().take(BURST_SIZE) {
+            let _ = Theme::from_name(theme_name);
+        }
+        burst_times.push(start.elapsed());
+    }
+
+    let stats = BenchmarkStats::new(burst_times);
+    stats.report(&format!("Rapid Theme Switching (bursts of {BURST_SIZE})"));
+
+    assert!(
+        (stats.mean / BURST_SIZE as u32) < Duration::from_micros(200),
+        "Average theme switch time in burst ({:?}) exceeded 200µs threshold",
+        stats.mean / BURST_SIZE as u32
+    );
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -298,6 +298,7 @@ mod tests {
 
         assert_eq!(config.use_symbols, false);
         assert_eq!(config.use_punctuation, false);
+        #[cfg(debug_assertions)]
         assert_eq!(config.debug, false);
     }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -68,7 +68,7 @@ impl InputHandler {
         }
     }
 
-    pub fn handle_input(&mut self, key: KeyEvent, menu: &MenuState, is_debug: bool) -> Action {
+    pub fn handle_input(&mut self, key: KeyEvent, menu: &MenuState, _is_debug: bool) -> Action {
         let last_key_cache = self.last_key;
         self.last_key = Some(key.code);
 
@@ -81,7 +81,7 @@ impl InputHandler {
         }
 
         #[cfg(debug_assertions)]
-        if is_debug {
+        if _is_debug {
             if let Some(action) = self.handle_debug_keys(&key) {
                 return action;
             }
@@ -416,6 +416,22 @@ fn execute_menu_action(action: MenuInputAction, state: &mut Termi) -> Action {
             } else {
                 let query = format!("{}{}", state.menu.search_query(), c);
                 state.menu.update_search(&query);
+            }
+            if let Some(menu) = state.menu.current_menu() {
+                if let Some(item) = menu.selected_item() {
+                    // TODO: eventually update other stuff like cursor style and language
+                    match &item.action {
+                        MenuAction::ChangeTheme(_) => {
+                            state.menu.preview_selected();
+                            state.update_preview_theme();
+                        }
+                        MenuAction::ChangeCursorStyle(_) => {
+                            state.menu.preview_selected();
+                            state.update_preview_cursor();
+                        }
+                        _ => {}
+                    }
+                }
             }
             Action::None
         }

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -190,13 +190,19 @@ impl Menu {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct MenuState {
     menu_stack: Vec<Menu>,
     preview_theme: Option<String>,
     preview_cursor: Option<String>,
     search_query: String,
     is_searching: bool,
+}
+
+impl Default for MenuState {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl MenuState {
@@ -572,6 +578,7 @@ impl MenuState {
         if let Some(menu) = self.current_menu() {
             if let Some(index) = self.find_best_match(menu, &self.search_query) {
                 self.select(index);
+                // self.preview_selected();
             }
         }
     }

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,1 +1,1 @@
-pub static VERSION: &str = "v0.0.1-alpha.17";
+pub static VERSION: &str = "v0.0.1-alpha.18";


### PR DESCRIPTION
Re-design the menu to feel and look like a dropdown terminal emulator (heavily inspired by the Quake/Doom consoles).

I think it flows better with our design as it allows the full test text and results screen to be shown (rather than hidden with the previous menu).


Also includes massive performance enhancements to theme loading.