### PR TITLE
fix: high wpm on start and mutable results screen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "termitype"
-version = "0.0.1-alpha.23"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "termitype"
 build = "build.rs"
 description = "Terminal-based typing test inspired by a certain typing test you might know."
-version = "0.0.1-alpha.23"
+version = "0.0.1"
 license = "MIT"
 categories = ["command-line-utilities", "games"]
 keywords = ["tui", "cli", "typing", "game"]

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ cargo run -- --debug
 ## Installation
 
 ```sh
-cargo install termitype@0.0.1-alpha.23
+cargo install termitype@0.0.1
 ```
 
 ### TODO

--- a/src/termi.rs
+++ b/src/termi.rs
@@ -254,6 +254,11 @@ pub fn run<B: Backend>(terminal: &mut Terminal<B>, config: &Config) -> Result<()
             }
         }
 
+        if termi.tracker.should_complete() {
+            termi.tracker.complete();
+            needs_redraw = true;
+        }
+
         if now.duration_since(last_metrics_update) >= Duration::from_millis(500) {
             termi.tracker.update_metrics();
             last_metrics_update = now;


### PR DESCRIPTION
There was a division by 0 that caused insanely high
WPM showing at the start of the test.

Also, fixed a bug were the the user could still keep
typing on the results screens thus changing the stats.

Fixes: #48There was a division by 0 that caused insanely high
WPM showing at the start of the test.

Also, fixed a bug were the the user could still keep
typing on the results screens thus changing the stats.

Fixes: #48