### PR TITLE
feat: custom modal input

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -88,7 +88,7 @@ pub struct Config {
     pub debug: bool,
 
     /// Shows the current frames per second (FPS).
-    #[arg(long = "fps")]
+    #[arg(long = "show-fps")]
     pub show_fps: bool,
 
     /// Stores the persistence of the game. Set automatically.

--- a/src/config.rs
+++ b/src/config.rs
@@ -87,6 +87,11 @@ pub struct Config {
     #[arg(short = 'd', long = "debug")]
     pub debug: bool,
 
+    /// Shows the current frames per second (FPS).
+    #[arg(long = "fps")]
+    pub show_fps: bool,
+
+    /// Stores the persistence of the game. Set automatically.
     #[arg(skip)]
     persistent: Option<Persistence>,
 }
@@ -130,6 +135,7 @@ impl Default for Config {
             list_themes: false,
             list_languages: false,
             version: false,
+            show_fps: false,
             #[cfg(debug_assertions)]
             debug: false,
             persistent: None,
@@ -470,6 +476,7 @@ mod tests {
         assert!(!config.use_punctuation);
         #[cfg(debug_assertions)]
         assert!(!config.debug);
+        assert!(!config.show_fps);
     }
 
     fn assert_mode(config: &Config, expected_mode: ModeType, expected_value: usize) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -96,7 +96,7 @@ pub struct Config {
     persistent: Option<Persistence>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum ModeType {
     Time = 0,
     Words = 1,

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,10 @@ use crossterm::cursor::SetCursorStyle;
 
 use crate::{
     builder::Builder,
-    constants::{DEFAULT_CURSOR_STYLE, DEFAULT_LANGUAGE, DEFAULT_LINE_COUNT, DEFAULT_THEME},
+    constants::{
+        DEFAULT_CURSOR_STYLE, DEFAULT_LANGUAGE, DEFAULT_LINE_COUNT, DEFAULT_THEME,
+        DEFAULT_TIME_MODE_DURATION, DEFAULT_WORD_MODE_COUNT,
+    },
     persistence::Persistence,
     theme::ThemeLoader,
 };
@@ -274,7 +277,7 @@ impl Config {
         match mode {
             ModeType::Time => {
                 self.word_count = None;
-                self.time = Some(value.unwrap_or(30) as u64);
+                self.time = Some(value.unwrap_or(DEFAULT_TIME_MODE_DURATION) as u64);
                 if let Some(persistence) = &mut self.persistent {
                     let _ = persistence.set("mode", "Time");
                     let _ = persistence.set("mode_value", &value.unwrap_or(30).to_string());
@@ -282,10 +285,13 @@ impl Config {
             }
             ModeType::Words => {
                 self.time = None;
-                self.word_count = Some(value.unwrap_or(25));
+                self.word_count = Some(value.unwrap_or(DEFAULT_WORD_MODE_COUNT));
                 if let Some(persistence) = &mut self.persistent {
                     let _ = persistence.set("mode", "Words");
-                    let _ = persistence.set("mode_value", &value.unwrap_or(25).to_string());
+                    let _ = persistence.set(
+                        "mode_value",
+                        &value.unwrap_or(DEFAULT_WORD_MODE_COUNT).to_string(),
+                    );
                 }
             }
         }
@@ -354,7 +360,7 @@ impl Config {
     pub fn resolve_word_count(&self) -> usize {
         match (self.time, self.word_count) {
             (None, Some(count)) => count,
-            _ => 100,
+            _ => DEFAULT_WORD_MODE_COUNT,
         }
     }
 
@@ -362,7 +368,7 @@ impl Config {
     pub fn resolve_duration(&self) -> u64 {
         match (self.time, self.word_count) {
             (Some(duration), None) => duration,
-            _ => 30,
+            _ => DEFAULT_TIME_MODE_DURATION as u64,
         }
     }
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -5,6 +5,9 @@ pub const DEFAULT_CURSOR_STYLE: &str = "blinking-beam";
 pub const DEFAULT_THEME: &str = "tokyonight";
 // pub const DEFAULT_THEME: &str = "termitype-dark";
 
+pub const DEFAULT_TIME_MODE_DURATION: usize = 30;
+pub const DEFAULT_WORD_MODE_COUNT: usize = 50;
+
 pub const STATE_FILE: &str = ".state";
 pub const LOG_FILE: &str = "debug.log";
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -48,6 +48,9 @@ pub const MIN_FOOTER_WIDTH: u16 = 55;
 
 pub const MENU_HEIGHT: u16 = 20;
 
+pub const MODAL_WIDTH: u16 = 50;
+pub const MODAL_HEIGHT: u16 = 11;
+
 // top area
 pub const HEADER_HEIGHT: u16 = 4;
 pub const ACTION_BAR_HEIGHT: u16 = 1;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -59,3 +59,10 @@ pub const COMMAND_BAR_HEIGHT: u16 = 3;
 pub const FOOTER_HEIGHT: u16 = 1;
 pub const BOTTOM_PADDING: u16 = 1;
 pub const BOTTOM_AREA_HEIGHT: u16 = COMMAND_BAR_HEIGHT + BOTTOM_PADDING + FOOTER_HEIGHT;
+
+// Modals
+pub const MIN_CUSTOM_TIME: u16 = 1;
+pub const MAX_CUSTOM_TIME: u16 = 100;
+
+pub const MIN_CUSTOM_WORD_COUNT: u16 = 1;
+pub const MAX_CUSTOM_WORD_COUNT: u16 = 5000;

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,7 +1,10 @@
 use crate::{
     config::ModeType,
-    constants::{BACKSPACE_CHAR, DEFAULT_LINE_COUNT},
+    constants::{
+        BACKSPACE_CHAR, DEFAULT_LINE_COUNT, DEFAULT_TIME_MODE_DURATION, DEFAULT_WORD_MODE_COUNT,
+    },
     menu::{self, MenuAction, MenuState},
+    modal::ModalContext,
     termi::Termi,
     theme::Theme,
     tracker::Status,
@@ -20,6 +23,15 @@ pub enum Action {
     TypeCharacter(char),
     Backspace,
     Menu(MenuInputAction),
+    Modal(ModalInputAction),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ModalInputAction {
+    TypeChar(char),
+    Backspace,
+    Confirm,
+    Close,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -55,12 +67,16 @@ impl InputHandler {
         }
     }
 
-    pub fn handle_input(&mut self, key: KeyEvent, menu: &MenuState, _is_debug: bool) -> Action {
+    pub fn handle_input(&mut self, key: KeyEvent, menu: &MenuState, modal_active: bool) -> Action {
         let last_key_cache = self.last_key;
         self.last_key = Some(key.code);
 
         if self.is_quit_sequence(&key) {
             return Action::Quit;
+        }
+
+        if modal_active {
+            return self.handle_modal_input(key);
         }
 
         if self.is_restart_sequence(&key.code, &last_key_cache) {
@@ -99,6 +115,16 @@ impl InputHandler {
                     Action::TypeCharacter(c)
                 }
             }
+            _ => Action::None,
+        }
+    }
+
+    fn handle_modal_input(&mut self, key: KeyEvent) -> Action {
+        match key.code {
+            KeyCode::Esc => Action::Modal(ModalInputAction::Close),
+            KeyCode::Enter => Action::Modal(ModalInputAction::Confirm),
+            KeyCode::Backspace => Action::Modal(ModalInputAction::Backspace),
+            KeyCode::Char(c) => Action::Modal(ModalInputAction::TypeChar(c)),
             _ => Action::None,
         }
     }
@@ -234,6 +260,56 @@ pub fn process_action(action: Action, state: &mut Termi) -> Action {
             Action::None
         }
         Action::Quit => Action::Quit,
+        Action::Modal(modal_action) => execute_modal_action(modal_action, state),
+    }
+}
+
+fn execute_modal_action(action: ModalInputAction, termi: &mut Termi) -> Action {
+    match action {
+        ModalInputAction::TypeChar(c) => {
+            if let Some(modal) = termi.modal.as_mut() {
+                modal.handle_char(c);
+            }
+            Action::None
+        }
+        ModalInputAction::Backspace => {
+            if let Some(modal) = termi.modal.as_mut() {
+                modal.handle_backspace();
+            }
+            Action::None
+        }
+        ModalInputAction::Close => {
+            if termi.modal.is_some() {
+                termi.modal = None;
+            }
+            Action::None
+        }
+        ModalInputAction::Confirm => {
+            // TODO: ensure that if we get here the input is valid.
+            if let Some(modal) = termi.modal.as_mut() {
+                match modal.ctx {
+                    ModalContext::CustomTime => termi.config.change_mode(
+                        ModeType::Time,
+                        Some(
+                            modal
+                                .get_value()
+                                .parse::<usize>()
+                                .unwrap_or(DEFAULT_TIME_MODE_DURATION),
+                        ),
+                    ),
+                    ModalContext::CustomWordCount => termi.config.change_mode(
+                        ModeType::Words,
+                        Some(
+                            modal
+                                .get_value()
+                                .parse::<usize>()
+                                .unwrap_or(DEFAULT_WORD_MODE_COUNT),
+                        ),
+                    ),
+                }
+            }
+            Action::None
+        }
     }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -434,7 +434,7 @@ fn execute_menu_action(action: MenuInputAction, state: &mut Termi) -> Action {
                         state.start();
                     }
                     MenuAction::Quit => return Action::Quit,
-                    MenuAction::OpenCustomModal(ctx) => {
+                    MenuAction::OpenModal(ctx) => {
                         state.modal = Some(build_modal(ctx));
                     }
                     _ => {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod input;
 pub mod log;
 pub mod macros;
 pub mod menu;
+pub mod modal;
 pub mod persistence;
 pub mod termi;
 pub mod theme;

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -509,7 +509,7 @@ impl MenuState {
             }
         });
         items.push(MenuItem::new(
-            "Custom...",
+            "custom...",
             MenuAction::OpenCustomModal(ModalContext::CustomTime),
         ));
         items
@@ -526,7 +526,7 @@ impl MenuState {
             }
         });
         items.push(MenuItem::new(
-            "Custom...",
+            "custom...",
             MenuAction::OpenCustomModal(ModalContext::CustomWordCount),
         ));
         items

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -1,10 +1,12 @@
 use crate::config::{Config, ModeType};
 use crate::constants::DEFAULT_THEME;
+use crate::modal::ModalContext;
 use crate::utils::fuzzy_match;
 use crate::version::VERSION;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum MenuAction {
+    OpenCustomModal(ModalContext),
     OpenMainMenu,
     ToggleThemePicker,
     OpenLanguagePicker,
@@ -351,7 +353,10 @@ impl MenuState {
             // return the other actions to be handled by the caller
             action => {
                 // clear menu stack for non-toggle actions
-                if !matches!(action, MenuAction::ToggleFeature(_)) {
+                if !matches!(
+                    action,
+                    MenuAction::ToggleFeature(_) | MenuAction::OpenCustomModal(_)
+                ) {
                     self.menu_stack.clear();
                     self.clear_previews();
                 }
@@ -495,26 +500,36 @@ impl MenuState {
 
     fn build_time_menu() -> Vec<MenuItem> {
         let times = vec![15, 30, 60, 120];
-        Self::build_generic_menu(times, MenuAction::ChangeTime, {
+        let mut items = Self::build_generic_menu(times, MenuAction::ChangeTime, {
             |a, b| {
                 a.label
                     .parse::<u32>()
                     .unwrap_or(0)
                     .cmp(&b.label.parse::<u32>().unwrap_or(0))
             }
-        })
+        });
+        items.push(MenuItem::new(
+            "Custom...",
+            MenuAction::OpenCustomModal(ModalContext::CustomTime),
+        ));
+        items
     }
 
     fn build_words_menu() -> Vec<MenuItem> {
         let word_counts = vec![10, 25, 50, 100];
-        Self::build_generic_menu(word_counts, MenuAction::ChangeWordCount, {
+        let mut items = Self::build_generic_menu(word_counts, MenuAction::ChangeWordCount, {
             |a, b| {
                 a.label
                     .parse::<u32>()
                     .unwrap_or(0)
                     .cmp(&b.label.parse::<u32>().unwrap_or(0))
             }
-        })
+        });
+        items.push(MenuItem::new(
+            "Custom...",
+            MenuAction::OpenCustomModal(ModalContext::CustomWordCount),
+        ));
+        items
     }
 
     fn build_visible_lines_menu() -> Vec<MenuItem> {

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -6,7 +6,7 @@ use crate::version::VERSION;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum MenuAction {
-    OpenCustomModal(ModalContext),
+    OpenModal(ModalContext),
     OpenMainMenu,
     ToggleThemePicker,
     OpenLanguagePicker,
@@ -353,12 +353,12 @@ impl MenuState {
             // return the other actions to be handled by the caller
             action => {
                 // clear menu stack for non-toggle actions
-                if !matches!(
-                    action,
-                    MenuAction::ToggleFeature(_) | MenuAction::OpenCustomModal(_)
-                ) {
+                if !matches!(action, MenuAction::ToggleFeature(_)) {
                     self.menu_stack.clear();
                     self.clear_previews();
+                }
+                if matches!(action, MenuAction::OpenModal(_)) {
+                    self.close();
                 }
                 Some(action)
             }
@@ -510,7 +510,7 @@ impl MenuState {
         });
         items.push(MenuItem::new(
             "custom...",
-            MenuAction::OpenCustomModal(ModalContext::CustomTime),
+            MenuAction::OpenModal(ModalContext::CustomTime),
         ));
         items
     }
@@ -527,7 +527,7 @@ impl MenuState {
         });
         items.push(MenuItem::new(
             "custom...",
-            MenuAction::OpenCustomModal(ModalContext::CustomWordCount),
+            MenuAction::OpenModal(ModalContext::CustomWordCount),
         ));
         items
     }

--- a/src/modal.rs
+++ b/src/modal.rs
@@ -1,15 +1,27 @@
+use crate::constants::{
+    MAX_CUSTOM_TIME, MAX_CUSTOM_WORD_COUNT, MIN_CUSTOM_TIME, MIN_CUSTOM_WORD_COUNT,
+};
+
+/// Used to determine which content to show on the modal
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum ModalContext {
+    CustomTime,
+    CustomWordCount,
+}
+
 #[derive(Debug, Clone)]
 pub struct InputBuffer {
     input: String,
     cursor_pos: usize,
     is_numeric: bool,
     error_msg: Option<String>,
-    min_value: u8,
-    max_value: u8,
+    min_value: u16,
+    max_value: u16,
 }
 
 #[derive(Debug, Clone)]
 pub struct InputModal {
+    pub ctx: ModalContext,
     pub title: String,
     pub description: String,
     pub buffer: InputBuffer,
@@ -18,6 +30,7 @@ pub struct InputModal {
 impl Default for InputModal {
     fn default() -> Self {
         Self {
+            ctx: ModalContext::CustomTime,
             title: "<title>".to_string(),
             description: "<description>".to_string(),
             buffer: InputBuffer {
@@ -33,8 +46,16 @@ impl Default for InputModal {
 }
 
 impl InputModal {
-    pub fn new(title: String, description: String, is_numeric: bool, min: u8, max: u8) -> Self {
+    pub fn new(
+        ctx: ModalContext,
+        title: String,
+        description: String,
+        is_numeric: bool,
+        min: u16,
+        max: u16,
+    ) -> Self {
         Self {
+            ctx,
             title,
             description,
             buffer: InputBuffer {
@@ -106,13 +127,44 @@ impl InputModal {
         }
     }
 }
+pub fn build_modal(ctx: ModalContext) -> InputModal {
+    match ctx {
+        ModalContext::CustomTime => InputModal {
+            ctx,
+            title: "Custom Time".to_string(),
+            description: "Enter desired test duration (seconds)".to_string(),
+            buffer: InputBuffer {
+                input: "".to_string(),
+                cursor_pos: 0,
+                is_numeric: true,
+                error_msg: None,
+                min_value: MIN_CUSTOM_TIME,
+                max_value: MAX_CUSTOM_TIME,
+            },
+        },
+        ModalContext::CustomWordCount => InputModal {
+            ctx,
+            title: "Custom Word Count".to_string(),
+            description: "Enter desired word count".to_string(),
+            buffer: InputBuffer {
+                input: "".to_string(),
+                cursor_pos: 0,
+                is_numeric: true,
+                error_msg: None,
+                min_value: MIN_CUSTOM_WORD_COUNT,
+                max_value: MAX_CUSTOM_WORD_COUNT,
+            },
+        },
+    }
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn create_custom_modal(is_numeric: bool, min: u8, max: u8) -> InputModal {
+    fn create_custom_modal(is_numeric: bool, min: u16, max: u16) -> InputModal {
         InputModal {
+            ctx: ModalContext::CustomTime,
             title: "Test Modal".to_string(),
             description: "Random Test Modal".to_string(),
             buffer: InputBuffer {

--- a/src/modal.rs
+++ b/src/modal.rs
@@ -11,12 +11,12 @@ pub enum ModalContext {
 
 #[derive(Debug, Clone)]
 pub struct InputBuffer {
-    input: String,
-    cursor_pos: usize,
-    is_numeric: bool,
-    error_msg: Option<String>,
-    min_value: u16,
-    max_value: u16,
+    pub input: String,
+    pub cursor_pos: usize,
+    pub is_numeric: bool,
+    pub error_msg: Option<String>,
+    pub min_value: u16,
+    pub max_value: u16,
 }
 
 #[derive(Debug, Clone)]
@@ -48,16 +48,16 @@ impl Default for InputModal {
 impl InputModal {
     pub fn new(
         ctx: ModalContext,
-        title: String,
-        description: String,
+        title: &str,
+        description: &str,
         is_numeric: bool,
         min: u16,
         max: u16,
     ) -> Self {
         Self {
             ctx,
-            title,
-            description,
+            title: title.to_string(),
+            description: description.to_string(),
             buffer: InputBuffer {
                 input: String::new(),
                 is_numeric,
@@ -72,7 +72,6 @@ impl InputModal {
     pub fn handle_char(&mut self, c: char) {
         let is_numeric = self.buffer.is_numeric;
         if (is_numeric && c.is_ascii_digit()) || (!is_numeric && c.is_alphabetic()) {
-            println!("Registering char: {c}");
             self.buffer.input.insert(self.buffer.cursor_pos, c);
             self.buffer.cursor_pos += 1;
             self.validate_input();
@@ -100,13 +99,12 @@ impl InputModal {
         if self.buffer.is_numeric {
             match self.buffer.input.parse::<u64>() {
                 Ok(value) => {
-                    let min_msg =
-                        Some(format!("Value must be at least: {}", self.buffer.min_value));
-                    let max_msg = Some(format!("Value must not exceed: {}", self.buffer.max_value));
+                    let min_msg = format!("Value must be at least: {}", self.buffer.min_value);
+                    let max_msg = format!("Value must not exceed: {}", self.buffer.max_value);
                     if value < self.buffer.min_value as u64 {
-                        self.buffer.error_msg = min_msg;
+                        self.buffer.error_msg = Some(min_msg);
                     } else if value > self.buffer.max_value as u64 {
-                        self.buffer.error_msg = max_msg;
+                        self.buffer.error_msg = Some(max_msg);
                     } else {
                         self.buffer.error_msg = None;
                     }
@@ -119,18 +117,19 @@ impl InputModal {
             let input_len = self.buffer.input.len();
             let min_len = self.buffer.min_value as usize;
             let max_len = self.buffer.max_value as usize;
-            let min_msg = Some(format!("Input must be at least {}", min_len));
-            let max_msg = Some(format!("Input must not exceed {}", max_len));
+            let min_msg = format!("Input must be at least {}", min_len);
+            let max_msg = format!("Input must not exceed {}", max_len);
             if input_len < min_len {
-                self.buffer.error_msg = min_msg;
+                self.buffer.error_msg = Some(min_msg);
             } else if input_len > max_len {
-                self.buffer.error_msg = max_msg;
+                self.buffer.error_msg = Some(max_msg);
             } else {
                 self.buffer.error_msg = None;
             }
         }
     }
 }
+
 pub fn build_modal(ctx: ModalContext) -> InputModal {
     match ctx {
         ModalContext::CustomTime => InputModal {
@@ -138,7 +137,7 @@ pub fn build_modal(ctx: ModalContext) -> InputModal {
             title: "Custom Time".to_string(),
             description: "Enter desired test duration (seconds)".to_string(),
             buffer: InputBuffer {
-                input: "".to_string(),
+                input: String::new(),
                 cursor_pos: 0,
                 is_numeric: true,
                 error_msg: None,
@@ -151,7 +150,7 @@ pub fn build_modal(ctx: ModalContext) -> InputModal {
             title: "Custom Word Count".to_string(),
             description: "Enter desired word count".to_string(),
             buffer: InputBuffer {
-                input: "".to_string(),
+                input: String::new(),
                 cursor_pos: 0,
                 is_numeric: true,
                 error_msg: None,

--- a/src/modal.rs
+++ b/src/modal.rs
@@ -87,6 +87,10 @@ impl InputModal {
         }
     }
 
+    pub fn get_value(&self) -> String {
+        self.buffer.input.clone()
+    }
+
     fn validate_input(&mut self) {
         if self.buffer.input.is_empty() {
             self.buffer.error_msg = Some("Input field cannot be empty".to_string());

--- a/src/modal.rs
+++ b/src/modal.rs
@@ -1,0 +1,190 @@
+#[derive(Debug, Clone)]
+pub struct InputBuffer {
+    input: String,
+    cursor_pos: usize,
+    is_numeric: bool,
+    error_msg: Option<String>,
+    min_value: u8,
+    max_value: u8,
+}
+
+#[derive(Debug, Clone)]
+pub struct InputModal {
+    pub title: String,
+    pub description: String,
+    pub buffer: InputBuffer,
+}
+
+impl Default for InputModal {
+    fn default() -> Self {
+        Self {
+            title: "<title>".to_string(),
+            description: "<description>".to_string(),
+            buffer: InputBuffer {
+                input: String::new(),
+                is_numeric: true,
+                cursor_pos: 0,
+                error_msg: None,
+                min_value: 1,
+                max_value: 5,
+            },
+        }
+    }
+}
+
+impl InputModal {
+    pub fn new(title: String, description: String, is_numeric: bool, min: u8, max: u8) -> Self {
+        Self {
+            title,
+            description,
+            buffer: InputBuffer {
+                input: String::new(),
+                is_numeric,
+                cursor_pos: 0,
+                error_msg: None,
+                min_value: min,
+                max_value: max,
+            },
+        }
+    }
+
+    pub fn handle_char(&mut self, c: char) {
+        let is_numeric = self.buffer.is_numeric;
+        if (is_numeric && c.is_ascii_digit()) || (!is_numeric && c.is_alphabetic()) {
+            println!("Registering char: {c}");
+            self.buffer.input.insert(self.buffer.cursor_pos, c);
+            self.buffer.cursor_pos += 1;
+            self.validate_input();
+        }
+    }
+
+    pub fn handle_backspace(&mut self) {
+        if self.buffer.cursor_pos > 0 {
+            self.buffer.cursor_pos -= 1;
+            self.buffer.input.remove(self.buffer.cursor_pos);
+            self.validate_input();
+        }
+    }
+
+    fn validate_input(&mut self) {
+        if self.buffer.input.is_empty() {
+            self.buffer.error_msg = Some("Input field cannot be empty".to_string());
+            return;
+        }
+
+        if self.buffer.is_numeric {
+            match self.buffer.input.parse::<u64>() {
+                Ok(value) => {
+                    let min_msg =
+                        Some(format!("Value must be at least: {}", self.buffer.min_value));
+                    let max_msg = Some(format!("Value must not exceed: {}", self.buffer.max_value));
+                    if value < self.buffer.min_value as u64 {
+                        self.buffer.error_msg = min_msg;
+                    } else if value > self.buffer.max_value as u64 {
+                        self.buffer.error_msg = max_msg;
+                    } else {
+                        self.buffer.error_msg = None;
+                    }
+                }
+                Err(_) => {
+                    self.buffer.error_msg = Some("Invalid number format.".to_string());
+                }
+            }
+        } else {
+            let input_len = self.buffer.input.len();
+            let min_len = self.buffer.min_value as usize;
+            let max_len = self.buffer.max_value as usize;
+            let min_msg = Some(format!("Input must be at least {}", min_len));
+            let max_msg = Some(format!("Input must not exceed {}", max_len));
+            if input_len < min_len {
+                self.buffer.error_msg = min_msg;
+            } else if input_len > max_len {
+                self.buffer.error_msg = max_msg;
+            } else {
+                self.buffer.error_msg = None;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_custom_modal(is_numeric: bool, min: u8, max: u8) -> InputModal {
+        InputModal {
+            title: "Test Modal".to_string(),
+            description: "Random Test Modal".to_string(),
+            buffer: InputBuffer {
+                input: String::new(),
+                cursor_pos: 0,
+                is_numeric,
+                error_msg: None,
+                min_value: min,
+                max_value: max,
+            },
+        }
+    }
+
+    #[test]
+    fn test_modal_creation() {
+        let modal = InputModal::default();
+        assert_eq!(modal.title, "<title>".to_string());
+        assert_eq!(modal.description, "<description>".to_string());
+        assert!(modal.buffer.input.is_empty());
+        assert!(modal.buffer.error_msg.is_none());
+    }
+
+    #[test]
+    fn test_numeric_input() {
+        let is_numeric = true;
+        let mut modal = create_custom_modal(is_numeric, 1, 3);
+        assert!(modal.buffer.input.is_empty());
+
+        assert!(modal.buffer.error_msg.is_none());
+        modal.handle_char('e');
+        assert!(modal.buffer.input.is_empty());
+
+        modal.handle_char('1');
+        assert!(modal.buffer.input.len() == 1);
+        assert!(modal.buffer.error_msg.is_none());
+        modal.handle_char('0'); // now the input should be 10
+        assert!(modal.buffer.error_msg.is_some());
+    }
+
+    #[test]
+    fn test_char_input() {
+        let is_numeric = false;
+        let mut modal = create_custom_modal(is_numeric, 1, 2);
+        assert!(modal.buffer.input.is_empty());
+
+        assert!(modal.buffer.error_msg.is_none());
+        modal.handle_char('1');
+        assert!(modal.buffer.input.is_empty());
+
+        modal.handle_char('e');
+        assert!(modal.buffer.input.len() == 1);
+        assert!(modal.buffer.error_msg.is_none());
+        modal.handle_char('e'); // now the input should be `ee`
+        assert!(modal.buffer.error_msg.is_none());
+        modal.handle_char('e'); // now the input should be `eee` exceeding max
+        assert!(modal.buffer.error_msg.is_some());
+    }
+    #[test]
+    fn test_backspace() {
+        let is_numeric = false;
+        let mut modal = create_custom_modal(is_numeric, 1, 1);
+        assert!(modal.buffer.input.is_empty());
+
+        modal.handle_char('e');
+        assert!(modal.buffer.input.len() == 1);
+        modal.handle_backspace();
+        assert!(modal.buffer.input.is_empty());
+
+        modal.handle_char('e');
+        modal.handle_char('e');
+        assert!(modal.buffer.error_msg.is_some()); // exceeds current max of `1`
+        modal.handle_backspace();
+        assert!(modal.buffer.error_msg.is_none());
+    }
+}

--- a/src/termi.rs
+++ b/src/termi.rs
@@ -152,7 +152,7 @@ impl Termi {
                                 }
                                 self.config
                                     .change_mode(ModeType::Time, Some(value.unwrap()));
-                                self.start()
+                                self.start();
                             }
                             ModalContext::CustomWordCount => {
                                 let value = modal.get_value().parse::<usize>();
@@ -161,7 +161,7 @@ impl Termi {
                                 }
                                 self.config
                                     .change_mode(ModeType::Words, Some(value.unwrap()));
-                                self.start()
+                                self.start();
                             }
                         }
                     }

--- a/src/termi.rs
+++ b/src/termi.rs
@@ -206,14 +206,6 @@ pub fn run<B: Backend>(terminal: &mut Terminal<B>, config: &Config) -> Result<()
             idle_frame_time
         };
 
-        if needs_redraw && now.duration_since(last_render) >= current_frame_time {
-            terminal.draw(|frame| {
-                clickable_regions = draw_ui(frame, &mut termi);
-            })?;
-            last_render = now;
-            needs_redraw = false;
-        }
-
         let timeout = current_frame_time
             .checked_sub(last_tick.elapsed())
             .unwrap_or_else(|| Duration::from_secs(0));
@@ -262,7 +254,14 @@ pub fn run<B: Backend>(terminal: &mut Terminal<B>, config: &Config) -> Result<()
         if now.duration_since(last_metrics_update) >= Duration::from_millis(500) {
             termi.tracker.update_metrics();
             last_metrics_update = now;
-            needs_redraw = true;
+        }
+
+        if needs_redraw && now.duration_since(last_render) >= current_frame_time {
+            terminal.draw(|frame| {
+                clickable_regions = draw_ui(frame, &mut termi);
+            })?;
+            last_render = now;
+            needs_redraw = false;
         }
 
         last_tick = Instant::now();

--- a/src/termi.rs
+++ b/src/termi.rs
@@ -231,7 +231,8 @@ pub fn run<B: Backend>(terminal: &mut Terminal<B>, config: &Config) -> Result<()
             match event::read()? {
                 Event::Key(key) => {
                     if key.kind == KeyEventKind::Press {
-                        let action = input_handler.handle_input(key, &termi.menu, false);
+                        let is_modal_active = termi.modal.is_some();
+                        let action = input_handler.handle_input(key, &termi.menu, is_modal_active);
 
                         if action == Action::Quit {
                             break;

--- a/src/termi.rs
+++ b/src/termi.rs
@@ -242,6 +242,7 @@ pub fn run<B: Backend>(terminal: &mut Terminal<B>, config: &Config) -> Result<()
                 }) => {
                     log_debug!("Status: {:?}", termi.tracker.status);
                     termi.handle_click(&clickable_regions, column, row);
+                    needs_redraw = true;
                 }
                 Event::Resize(_width, _height) => {
                     needs_redraw = true;

--- a/src/termi.rs
+++ b/src/termi.rs
@@ -9,6 +9,7 @@ use crossterm::{
 };
 use ratatui::{layout::Position, prelude::Backend, Terminal};
 
+use crate::modal::{build_modal, InputModal};
 use crate::{
     builder::Builder,
     config::Config,
@@ -29,6 +30,7 @@ pub struct Termi {
     pub builder: Builder,
     pub words: String,
     pub menu: MenuState,
+    pub modal: Option<InputModal>,
 }
 
 impl std::fmt::Debug for Termi {
@@ -46,7 +48,8 @@ impl std::fmt::Debug for Termi {
             )
             .field("builder", &self.builder)
             .field("words", &self.words)
-            .field("menu", &self.menu);
+            .field("menu", &self.words)
+            .field("modal", &self.modal);
 
         debug_struct.finish()
     }
@@ -69,6 +72,7 @@ impl Termi {
             builder,
             words,
             menu,
+            modal: None,
         }
     }
 
@@ -126,6 +130,14 @@ impl Termi {
                 TermiClickAction::ToggleMenu => {
                     self.menu.toggle(&self.config);
                 }
+                TermiClickAction::ToggleModal(ctx) => {
+                    if self.modal.is_some() {
+                        self.modal = None;
+                    } else {
+                        self.modal = Some(build_modal(ctx));
+                    }
+                }
+                TermiClickAction::ModalConfirm => todo!(),
             }
         }
     }

--- a/src/ui/actions.rs
+++ b/src/ui/actions.rs
@@ -1,6 +1,6 @@
-use crate::config::ModeType;
+use crate::{config::ModeType, modal::ModalContext};
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum TermiClickAction {
     SwitchMode(ModeType),
     SetModeValue(usize),
@@ -11,4 +11,6 @@ pub enum TermiClickAction {
     ToggleThemePicker,
     ToggleLanguagePicker,
     ToggleAbout,
+    ToggleModal(ModalContext),
+    ModalConfirm,
 }

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -140,7 +140,9 @@ pub fn draw_ui(frame: &mut Frame, termi: &mut Termi, fps: Option<f64>) -> TermiC
     }
 
     if let Some(modal) = &termi.modal {
-        render_modal(frame, termi, area, modal.clone());
+        if let Some(region) = render_modal(frame, termi, area, modal.clone()) {
+            regions.add(region.0, region.1);
+        }
     }
 
     if let Some((widget, fps_area)) = fps_widget {
@@ -299,7 +301,12 @@ fn render_typing_area(frame: &mut Frame, termi: &Termi, area: Rect) {
     }
 }
 
-fn render_modal(frame: &mut Frame, termi: &Termi, area: Rect, modal: InputModal) {
+fn render_modal(
+    frame: &mut Frame,
+    termi: &Termi,
+    area: Rect,
+    modal: InputModal,
+) -> Option<(Rect, TermiClickAction)> {
     let theme = termi.theme.clone();
     let modal_area = center_div(MODAL_WIDTH, MODAL_HEIGHT, area);
     frame.render_widget(Clear, modal_area);
@@ -380,6 +387,7 @@ fn render_modal(frame: &mut Frame, termi: &Termi, area: Rect, modal: InputModal)
         x: input_area.x + modal.buffer.cursor_pos as u16,
         y: input_area.y,
     });
+    Some((ok_area, TermiClickAction::ModalConfirm))
 }
 
 fn render_menu(frame: &mut Frame, termi: &Termi, area: Rect) {

--- a/src/ui/utils.rs
+++ b/src/ui/utils.rs
@@ -1,3 +1,5 @@
+use ratatui::layout::Rect;
+
 // TODO: maybe having this file is not entirely needed question mark
 #[derive(Debug, Clone, Copy)]
 pub struct WordPosition {
@@ -5,6 +7,20 @@ pub struct WordPosition {
     pub line: usize,
     pub col: usize,
 }
+
+pub fn center_div(width: u16, height: u16, parent: Rect) -> Rect {
+    let parent_w = parent.width;
+    let parent_h = parent.height;
+
+    let width = width.min(parent_w);
+    let height = height.min(parent_h);
+
+    let x = parent.x + (parent_w.saturating_sub(width)) / 2;
+    let y = parent.y + (parent_h.saturating_sub(height)) / 2;
+
+    Rect::new(x, y, width, height)
+}
+
 pub fn calculate_word_positions(text: &str, available_width: usize) -> Vec<WordPosition> {
     if text.is_empty() || available_width == 0 {
         return vec![];


### PR DESCRIPTION
Adds the ability to change runtime behavior via custom modal inputs.

Only contains two type of modals at the moment but more will/can be added in the near future.

Next up modals:

1. Custom visible line counts
2. Custom test words

Closes: #51 