### PR TITLE
fix: improve color support detection

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use clap::{ArgGroup, Parser};
 use crossterm::cursor::SetCursorStyle;
 
@@ -8,7 +10,7 @@ use crate::{
         DEFAULT_TIME_MODE_DURATION, DEFAULT_WORD_MODE_COUNT,
     },
     persistence::Persistence,
-    theme::ThemeLoader,
+    theme::{ColorSupport, Theme, ThemeLoader},
 };
 
 #[derive(Parser, Debug, Clone)]
@@ -457,6 +459,16 @@ impl Config {
         let val = !self.use_symbols;
         self.use_symbols = val;
         self.set_symbols(val);
+    }
+
+    /// Chesk if the current terminal has proper color support. Mainly used for themes
+    pub fn term_has_color_support(&self) -> bool {
+        let color_support = self
+            .color_mode
+            .as_deref()
+            .and_then(|s| ColorSupport::from_str(s).ok())
+            .unwrap_or_else(Theme::detect_color_support);
+        color_support.supports_themes()
     }
 }
 

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -39,6 +39,7 @@ pub struct MenuItem {
     pub has_submenu: bool,
     pub is_active: bool,
     pub is_toggleable: bool,
+    pub is_disabled: bool,
 }
 
 impl MenuItem {
@@ -49,6 +50,7 @@ impl MenuItem {
             is_active: false,
             has_submenu: false,
             is_toggleable: false,
+            is_disabled: false,
         }
     }
 
@@ -60,6 +62,11 @@ impl MenuItem {
 
     pub fn submenufy(mut self) -> Self {
         self.has_submenu = true;
+        self
+    }
+
+    pub fn disabled(mut self, is_disabled: bool) -> Self {
+        self.is_disabled = is_disabled;
         self
     }
 }
@@ -285,14 +292,16 @@ impl MenuState {
                 None
             }
             MenuAction::ToggleThemePicker => {
-                let mut menu = Menu::new(Self::build_theme_picker());
-                if let Some(index) = Self::get_label_index(
-                    menu.items(),
-                    config.theme.as_deref().unwrap_or(DEFAULT_THEME),
-                ) {
-                    menu.select(index);
+                if config.term_has_color_support() {
+                    let mut menu = Menu::new(Self::build_theme_picker());
+                    if let Some(index) = Self::get_label_index(
+                        menu.items(),
+                        config.theme.as_deref().unwrap_or(DEFAULT_THEME),
+                    ) {
+                        menu.select(index);
+                    }
+                    self.menu_stack.push(menu);
                 }
-                self.menu_stack.push(menu);
                 None
             }
             MenuAction::OpenLanguagePicker => {
@@ -416,7 +425,9 @@ impl MenuState {
             MenuItem::new("Time...", MenuAction::OpenTimePicker).submenufy(),
             MenuItem::new("Words...", MenuAction::OpenWordsPicker).submenufy(),
             MenuItem::new("Language...", MenuAction::OpenLanguagePicker).submenufy(),
-            MenuItem::new("Theme...", MenuAction::ToggleThemePicker).submenufy(),
+            MenuItem::new("Theme...", MenuAction::ToggleThemePicker)
+                .submenufy()
+                .disabled(!config.term_has_color_support()),
             MenuItem::new("Cursor...", MenuAction::OpenCursorPicker).submenufy(),
             MenuItem::new("Visible Lines...", MenuAction::OpenVisibleLines).submenufy(),
             MenuItem::new("About...", MenuAction::OpenAbout).submenufy(),

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -694,6 +694,7 @@ impl MenuState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::env;
 
     fn create_test_menu() -> MenuState {
         MenuState::new()
@@ -718,6 +719,10 @@ mod tests {
 
     #[test]
     fn test_theme_picker() {
+        // must set this manually as the theme sub-menu is disbabled if the
+        // current environment doesn't have proper color support and without it
+        // this test will fail in CI for example.
+        env::set_var("COLORTERM", "truecolor");
         let mut menu = create_test_menu();
         menu.toggle(&Config::default());
 

--- a/src/termi.rs
+++ b/src/termi.rs
@@ -109,14 +109,16 @@ impl Termi {
                     self.start();
                 }
                 TermiClickAction::ToggleThemePicker => {
-                    if self.menu.get_preview_theme().is_some() {
-                        self.menu.close();
-                        self.preview_theme = None;
-                    } else {
-                        self.menu
-                            .toggle_from_footer(&self.config, MenuAction::ToggleThemePicker);
-                        self.menu.preview_selected();
-                        self.update_preview_theme();
+                    if self.theme.color_support.supports_themes() {
+                        if self.menu.get_preview_theme().is_some() {
+                            self.menu.close();
+                            self.preview_theme = None;
+                        } else {
+                            self.menu
+                                .toggle_from_footer(&self.config, MenuAction::ToggleThemePicker);
+                            self.menu.preview_selected();
+                            self.update_preview_theme();
+                        }
                     }
                 }
                 TermiClickAction::ToggleLanguagePicker => {

--- a/src/ui/elements.rs
+++ b/src/ui/elements.rs
@@ -488,7 +488,9 @@ pub fn build_menu_items(
                         .map(|&(i, item)| {
                             let is_selected = i == menu.selected_index();
                             let item_style = Style::default()
-                                .fg(if item.is_toggleable {
+                                .fg(if item.is_disabled {
+                                    theme.muted()
+                                } else if item.is_toggleable {
                                     if item.is_active {
                                         theme.highlight()
                                     } else {
@@ -499,7 +501,7 @@ pub fn build_menu_items(
                                 } else {
                                     theme.fg()
                                 })
-                                .bg(if is_selected {
+                                .bg(if is_selected && !item.is_disabled {
                                     theme.selection_bg()
                                 } else {
                                     theme.bg()


### PR DESCRIPTION
- improves the way the fallback theme looks.
- does not even allow to browse themes if the terminal do not have proper color support

Closes: #10 