### PR TITLE
feat: add theme preview window on the menu

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -48,7 +48,7 @@ pub const SMALL_RESULTS_HEIGHT: u16 = 20;
 pub const MIN_TERM_HEIGHT: u16 = 15;
 pub const MIN_TERM_WIDTH: u16 = 35;
 pub const MIN_FOOTER_WIDTH: u16 = 55;
-pub const MIN_THEME_PREVIEW_WIDTH: u16 = 50;
+pub const MIN_THEME_PREVIEW_WIDTH: u16 = 60;
 
 pub const MENU_HEIGHT: u16 = 25;
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -42,6 +42,9 @@ pub const DAYS_PER_MONTH: u64 = 30;
 pub const SMALL_TERM_WIDTH: u16 = 85;
 pub const SMALL_TERM_HEIGHT: u16 = 20;
 
+pub const SMALL_RESULTS_WIDTH: u16 = 60;
+pub const SMALL_RESULTS_HEIGHT: u16 = 20;
+
 pub const MIN_TERM_HEIGHT: u16 = 15;
 pub const MIN_TERM_WIDTH: u16 = 35;
 pub const MIN_FOOTER_WIDTH: u16 = 55;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -45,8 +45,9 @@ pub const SMALL_TERM_HEIGHT: u16 = 20;
 pub const MIN_TERM_HEIGHT: u16 = 15;
 pub const MIN_TERM_WIDTH: u16 = 35;
 pub const MIN_FOOTER_WIDTH: u16 = 55;
+pub const MIN_THEME_PREVIEW_WIDTH: u16 = 50;
 
-pub const MENU_HEIGHT: u16 = 20;
+pub const MENU_HEIGHT: u16 = 25;
 
 pub const MODAL_WIDTH: u16 = 50;
 pub const MODAL_HEIGHT: u16 = 11;

--- a/src/input.rs
+++ b/src/input.rs
@@ -17,6 +17,7 @@ pub enum Action {
     None,
     Start,
     TogglePause,
+    ToggleThemePicker,
     Quit,
     TypeCharacter(char),
     Backspace,
@@ -98,6 +99,9 @@ impl InputHandler {
                 self.pending_accent = None;
                 Action::TogglePause
             }
+            // NOTE: ctrl-t is a nice keybind for toggling the theme picker but it might
+            // conflict with users keybinds (i.e terminal tabs on linux for those that use them)
+            // (KeyCode::Char('t'), KeyModifiers::CONTROL) => Action::ToggleThemePicker,
             (KeyCode::Char(c), KeyModifiers::ALT) => {
                 self.pending_accent = Some(c);
                 Action::None
@@ -150,12 +154,16 @@ impl InputHandler {
             };
         }
 
-        match key.code {
-            KeyCode::Char('/') => Action::Menu(MenuInputAction::StartSearch),
-            KeyCode::Char('k') | KeyCode::Up => Action::Menu(MenuInputAction::Up),
-            KeyCode::Char('j') | KeyCode::Down => Action::Menu(MenuInputAction::Down),
-            KeyCode::Enter => Action::Menu(MenuInputAction::Select),
-            KeyCode::Char('l') => {
+        match (key.code, key.modifiers) {
+            (KeyCode::Char('/'), KeyModifiers::NONE) => Action::Menu(MenuInputAction::StartSearch),
+            (KeyCode::Char('k') | KeyCode::Up, KeyModifiers::NONE) => {
+                Action::Menu(MenuInputAction::Up)
+            }
+            (KeyCode::Char('j') | KeyCode::Down, KeyModifiers::NONE) => {
+                Action::Menu(MenuInputAction::Down)
+            }
+            (KeyCode::Enter, KeyModifiers::NONE) => Action::Menu(MenuInputAction::Select),
+            (KeyCode::Char('l'), KeyModifiers::NONE) => {
                 if let Some(menu) = menu.current_menu() {
                     if menu.current_item().has_submenu {
                         return Action::Menu(MenuInputAction::Select);
@@ -163,7 +171,7 @@ impl InputHandler {
                 }
                 Action::None
             }
-            KeyCode::Char(' ') => {
+            (KeyCode::Char(' '), KeyModifiers::NONE) => {
                 if let Some(menu) = menu.current_menu() {
                     if menu.current_item().is_toggleable {
                         return Action::Menu(MenuInputAction::Select);
@@ -171,7 +179,7 @@ impl InputHandler {
                 }
                 Action::None
             }
-            KeyCode::Char('h') | KeyCode::Esc => {
+            (KeyCode::Char('h') | KeyCode::Esc, KeyModifiers::NONE) => {
                 if menu.should_close_completely() {
                     Action::Menu(MenuInputAction::Close)
                 } else if menu.menu_depth() > 1 {
@@ -180,6 +188,9 @@ impl InputHandler {
                     Action::Menu(MenuInputAction::Close)
                 }
             }
+            // NOTE: ctrl-t is a nice keybind for toggling the theme picker but it might
+            // conflict with users keybinds (i.e terminal tabs on linux for those that use them)
+            // (KeyCode::Char('t'), KeyModifiers::CONTROL) => Action::ToggleThemePicker,
             _ => Action::None,
         }
     }
@@ -231,6 +242,10 @@ pub fn process_action(action: Action, state: &mut Termi) -> Action {
             state.tracker.type_char(char);
             Action::None
         }
+        Action::ToggleThemePicker => {
+            state.menu.toggle_theme_picker(&state.config);
+            Action::None
+        }
         Action::Backspace => {
             if state.menu.is_open() {
                 return Action::None;
@@ -253,7 +268,7 @@ pub fn process_action(action: Action, state: &mut Termi) -> Action {
             } else {
                 state.tracker.pause();
             }
-            state.menu.toggle(&state.config);
+            state.menu.toggle_menu(&state.config);
 
             Action::None
         }

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -689,6 +689,16 @@ impl MenuState {
             })
             .unwrap_or(false)
     }
+
+    pub fn is_theme_menu(&self) -> bool {
+        if !self.is_open() {
+            return false;
+        }
+        self.current_menu()
+            .and_then(|menu| menu.selected_item())
+            .map(|item| matches!(item.action, MenuAction::ChangeTheme(_)))
+            .unwrap_or(false)
+    }
 }
 
 #[cfg(test)]

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -247,7 +247,7 @@ impl MenuState {
         self.menu_stack.last_mut()
     }
 
-    pub fn toggle(&mut self, config: &Config) {
+    pub fn toggle_menu(&mut self, config: &Config) {
         if self.is_open() {
             self.menu_stack.clear();
             self.clear_previews();
@@ -256,6 +256,10 @@ impl MenuState {
             self.execute(MenuAction::OpenMainMenu, config);
             self.opened_from_footer = false;
         }
+    }
+
+    pub fn toggle_theme_picker(&mut self, config: &Config) {
+        self.execute(MenuAction::ToggleThemePicker, config);
     }
 
     pub fn back(&mut self) {
@@ -292,6 +296,10 @@ impl MenuState {
                 None
             }
             MenuAction::ToggleThemePicker => {
+                if self.is_theme_menu() {
+                    self.close();
+                    return None;
+                }
                 if config.term_has_color_support() {
                     let mut menu = Menu::new(Self::build_theme_picker());
                     if let Some(index) = Self::get_label_index(
@@ -713,7 +721,7 @@ mod tests {
     #[test]
     fn test_menu_navigation() {
         let mut menu = create_test_menu();
-        menu.toggle(&Config::default());
+        menu.toggle_menu(&Config::default());
         assert!(menu.is_open());
 
         assert!(menu.next_item());
@@ -734,7 +742,7 @@ mod tests {
         // this test will fail in CI for example.
         env::set_var("COLORTERM", "truecolor");
         let mut menu = create_test_menu();
-        menu.toggle(&Config::default());
+        menu.toggle_menu(&Config::default());
 
         let theme_index = if let Some(menu_ref) = menu.current_menu() {
             menu_ref
@@ -774,7 +782,7 @@ mod tests {
     fn test_toggle_features() {
         let mut menu = create_test_menu();
         let mut config = Config::default();
-        menu.toggle(&Config::default());
+        menu.toggle_menu(&Config::default());
         config.use_punctuation = true;
 
         menu.update_toggles(&config);
@@ -790,7 +798,7 @@ mod tests {
     #[test]
     fn test_search_functionality() {
         let mut menu = create_test_menu();
-        menu.toggle(&Config::default());
+        menu.toggle_menu(&Config::default());
         assert!(!menu.is_searching());
 
         // start search

--- a/src/termi.rs
+++ b/src/termi.rs
@@ -10,7 +10,6 @@ use crossterm::{
 use ratatui::{layout::Position, prelude::Backend, Terminal};
 
 use crate::config::ModeType;
-use crate::constants::MIN_THEME_PREVIEW_WIDTH;
 use crate::modal::{build_modal, InputModal, ModalContext};
 use crate::{
     builder::Builder,
@@ -204,19 +203,13 @@ impl Termi {
         if let Some(theme_name) = self.menu.get_preview_theme() {
             self.preview_theme_name = Some(theme_name.clone());
 
-            let (width, _) = crossterm::terminal::size().unwrap_or((0, 0));
+            let needs_update = match &self.preview_theme {
+                None => true,
+                Some(current_theme) => current_theme.id != *theme_name,
+            };
 
-            if width <= MIN_THEME_PREVIEW_WIDTH {
-                let needs_update = match &self.preview_theme {
-                    None => true,
-                    Some(current_theme) => current_theme.id != *theme_name,
-                };
-
-                if needs_update {
-                    self.preview_theme = Some(Theme::from_name(theme_name));
-                }
-            } else {
-                self.preview_theme = None;
+            if needs_update {
+                self.preview_theme = Some(Theme::from_name(theme_name));
             }
         } else {
             self.preview_theme_name = None;

--- a/src/termi.rs
+++ b/src/termi.rs
@@ -134,7 +134,7 @@ impl Termi {
                         .toggle_from_footer(&self.config, MenuAction::OpenAbout);
                 }
                 TermiClickAction::ToggleMenu => {
-                    self.menu.toggle(&self.config);
+                    self.menu.toggle_menu(&self.config);
                 }
                 TermiClickAction::ToggleModal(ctx) => {
                     if self.modal.is_some() {

--- a/src/termi.rs
+++ b/src/termi.rs
@@ -115,12 +115,12 @@ impl Termi {
                     if self.theme.color_support.supports_themes() {
                         if self.menu.get_preview_theme().is_some() {
                             self.menu.close();
-                            self.preview_theme = None;
+                            self.update_preview_theme();
                         } else {
                             self.menu
                                 .toggle_from_footer(&self.config, MenuAction::ToggleThemePicker);
-                            self.menu.preview_selected();
                             self.update_preview_theme();
+                            self.menu.preview_selected();
                         }
                     }
                 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -424,7 +424,7 @@ impl ThemeLoader {
         colors[ThemeColor::Success as usize] = parse_color("palette2")?;
         colors[ThemeColor::Error as usize] = parse_color("palette1")?;
         colors[ThemeColor::Cursor as usize] = parse_color("cursor-color")?;
-        colors[ThemeColor::CursorText as usize] = parse_color("cursor-text")?;
+        colors[ThemeColor::CursorText as usize] = parse_color("palette0")?;
         colors[ThemeColor::SelectionBg as usize] = parse_color("selection-background")?;
         colors[ThemeColor::SelectionFg as usize] = parse_color("selection-foreground")?;
 
@@ -492,6 +492,7 @@ mod tests {
             cursor-text = #000000
             selection-background = #333333
             selection-foreground =  #ffffff
+            palette0 = #ff0000
             palette1 = #ff0000
             palette2 = #00ff00
             palette3 = #ffff00
@@ -521,6 +522,7 @@ mod tests {
             cursor-text = #000000
             selection-background = #333333
             selection-foreground = #ffffff
+            palette0 = #ff0000
             palette1 = #ff0000
             palette2 = #00ff00
             palette3 = #ffff00
@@ -547,6 +549,7 @@ mod tests {
             cursor-color = #cccccc
             cursor-text = #000000
             selection-background = #333333
+            palette0 = #ff0000
             palette1 = #ff0000
             palette2 = #00ff00
             palette3 = #ffff00
@@ -568,6 +571,7 @@ mod tests {
             cursor-color = #cccccc
             cursor-text = #000000
             selection-background = #333333
+            palette0 = #ff0000
             palette1 = #ff0000
             palette2 = #00ff00
             palette3 = #ffff00

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -924,6 +924,26 @@ mod tests {
     }
 
     #[test]
+    fn test_partial_wrong_word_fix() {
+        let config = Config::default();
+        let target_text = String::from("hello world");
+        let mut tracker = Tracker::new(&config, target_text);
+        tracker.start_typing();
+        tracker.type_char('f');
+        tracker.type_char('f');
+        tracker.type_char('f');
+        tracker.type_char('f');
+        tracker.type_char('f');
+
+        tracker.backspace();
+        tracker.backspace();
+        tracker.type_char('l');
+        tracker.type_char('0');
+        tracker.type_char(' ');
+        assert!(tracker.is_word_wrong(0), "Word should be marked wrong");
+    }
+
+    #[test]
     fn test_backspace_at_word_boundary_behavior() {
         let config = Config::default();
         let target_text = String::from("hello world");

--- a/src/ui/elements.rs
+++ b/src/ui/elements.rs
@@ -211,71 +211,97 @@ pub fn create_mode_bar(termi: &Termi) -> Vec<TermiElement> {
     vec![element]
 }
 
-pub fn create_styled_typing_text<'a>(
-    termi: &'a Termi,
-    theme: &Theme,
-    width: Option<usize>,
-) -> Text<'a> {
-    let width = width.unwrap_or(100);
+pub fn create_typing_area(
+    termi: &Termi,
+    width: usize,
+    scroll_offset: usize,
+    visible_line_count: usize,
+) -> Text {
     let word_positions = calculate_word_positions(&termi.words, width);
+    let theme = &termi.theme;
+
+    if word_positions.is_empty() {
+        return Text::raw("");
+    }
 
     let words: Vec<&str> = termi.words.split_whitespace().collect();
-    let mut lines: Vec<Line> =
-        Vec::with_capacity(word_positions.last().map(|p| p.line + 1).unwrap_or(1));
-    let mut curr_line = 0;
-    let mut curr_line_spans = Vec::new();
+    let mut lines: Vec<Line> = Vec::with_capacity(visible_line_count);
+
+    let first_line_to_render = scroll_offset;
+    let last_line_to_render = scroll_offset + visible_line_count.saturating_sub(1);
+
+    let mut current_line_spans = Vec::new();
+    let mut current_line_idx_in_full_text = 0;
+
+    if let Some(first_pos) = word_positions.first() {
+        current_line_idx_in_full_text = first_pos.line;
+    }
 
     for (i, pos) in word_positions.iter().enumerate() {
-        if pos.line > curr_line {
-            lines.push(Line::from(std::mem::take(&mut curr_line_spans)));
-            curr_line = pos.line;
-        }
-
-        let word = words.get(i).unwrap_or(&"");
-        let word_start = pos.start_index;
-        let word_len = word.chars().count();
-
-        let cursor_pos = termi.tracker.cursor_position;
-        let is_word_wrong = termi.tracker.is_word_wrong(word_start);
-        let is_past_word = cursor_pos > word_start + word_len;
-        let should_underline_word =
-            is_word_wrong && is_past_word && theme.color_support.supports_themes();
-
-        for (char_i, c) in word.chars().enumerate() {
-            let char_idx = word_start + char_i;
-            let base_style = match termi.tracker.user_input.get(char_idx).copied().flatten() {
-                Some(input) if input == c => Style::default().fg(theme.success()),
-                Some(_) => Style::default().fg(theme.error()),
-                None => Style::default().fg(theme.fg()).add_modifier(Modifier::DIM),
-            };
-
-            let style = if should_underline_word {
-                base_style
-                    .add_modifier(Modifier::UNDERLINED)
-                    .underline_color(theme.error())
+        if pos.line > current_line_idx_in_full_text {
+            if current_line_idx_in_full_text >= first_line_to_render
+                && current_line_idx_in_full_text <= last_line_to_render
+            {
+                if !current_line_spans.is_empty() {
+                    lines.push(Line::from(std::mem::take(&mut current_line_spans)));
+                }
             } else {
-                base_style
-            };
+                current_line_spans.clear();
+            }
+            current_line_idx_in_full_text = pos.line;
 
-            curr_line_spans.push(Span::styled(String::from(c), style));
+            if lines.len() >= visible_line_count {
+                break;
+            }
         }
 
-        if i < words.len() - 1 {
-            curr_line_spans.push(Span::raw(" "));
+        if pos.line >= first_line_to_render && pos.line <= last_line_to_render {
+            let word = words.get(i).unwrap_or(&"");
+            let word_start = pos.start_index;
+            let word_len = word.chars().count();
+
+            let cursor_pos = termi.tracker.cursor_position;
+            let is_word_wrong = termi.tracker.is_word_wrong(word_start);
+            let is_past_word = cursor_pos > word_start + word_len;
+            let should_underline_word =
+                is_word_wrong && is_past_word && theme.color_support.supports_themes();
+
+            for (char_i, c) in word.chars().enumerate() {
+                let char_idx = word_start + char_i;
+                let base_style = match termi.tracker.user_input.get(char_idx).copied().flatten() {
+                    Some(input) if input == c => Style::default().fg(theme.success()),
+                    Some(_) => Style::default().fg(theme.error()),
+                    None => Style::default().fg(theme.fg()).add_modifier(Modifier::DIM),
+                };
+
+                let style = if should_underline_word {
+                    base_style
+                        .add_modifier(Modifier::UNDERLINED)
+                        .underline_color(theme.error())
+                } else {
+                    base_style
+                };
+                current_line_spans.push(Span::styled(String::from(c), style));
+            }
+            if i < words.len() - 1
+                && word_positions
+                    .get(i + 1)
+                    .is_some_and(|next_pos| next_pos.line == pos.line)
+            {
+                current_line_spans.push(Span::raw(" "));
+            }
         }
     }
 
-    if !curr_line_spans.is_empty() {
-        lines.push(Line::from(curr_line_spans));
+    if !current_line_spans.is_empty()
+        && current_line_idx_in_full_text >= first_line_to_render
+        && current_line_idx_in_full_text <= last_line_to_render
+        && lines.len() < visible_line_count
+    {
+        lines.push(Line::from(current_line_spans));
     }
 
     Text::from(lines)
-}
-
-pub fn create_typing_area(termi: &Termi) -> Vec<TermiElement> {
-    let theme = termi.get_current_theme().clone();
-    let text = create_styled_typing_text(termi, &theme, None);
-    vec![TermiElement::new(text, false, None)]
 }
 
 pub fn create_command_bar(termi: &Termi) -> Vec<TermiElement> {

--- a/src/ui/elements.rs
+++ b/src/ui/elements.rs
@@ -93,7 +93,7 @@ pub fn create_action_bar(termi: &Termi) -> Vec<TermiElement> {
     };
 
     let supports_unicode = theme.supports_unicode();
-    let punct_symbol = if supports_unicode { "@" } else { "P" };
+    let punct_symbol = if supports_unicode { "!" } else { "P" };
     let num_symbol = if supports_unicode { "#" } else { "N" };
     let symbol_symbol = if supports_unicode { "@" } else { "S" };
     let divider = if supports_unicode { "│" } else { "|" };

--- a/src/ui/elements.rs
+++ b/src/ui/elements.rs
@@ -535,6 +535,11 @@ pub fn build_menu_items(
                                     theme.selection_bg()
                                 } else {
                                     theme.bg()
+                                })
+                                .add_modifier(if item.is_toggleable && !item.is_active {
+                                    Modifier::DIM
+                                } else {
+                                    Modifier::empty()
                                 });
 
                             ListItem::new(Line::from(vec![

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -2,7 +2,8 @@ use crate::{
     constants::{
         ACTION_BAR_HEIGHT, BOTTOM_AREA_HEIGHT, BOTTOM_PADDING, COMMAND_BAR_HEIGHT, FOOTER_HEIGHT,
         HEADER_HEIGHT, MIN_FOOTER_WIDTH, MIN_TERM_HEIGHT, MIN_TERM_WIDTH, MODE_BAR_HEIGHT,
-        SMALL_TERM_HEIGHT, SMALL_TERM_WIDTH, TOP_AREA_HEIGHT, TYPING_AREA_WIDTH_PERCENT,
+        SMALL_RESULTS_HEIGHT, SMALL_RESULTS_WIDTH, SMALL_TERM_HEIGHT, SMALL_TERM_WIDTH,
+        TOP_AREA_HEIGHT, TYPING_AREA_WIDTH_PERCENT,
     },
     termi::Termi,
 };
@@ -43,6 +44,10 @@ impl TermiLayout {
 
     pub fn show_footer(&self) -> bool {
         self.area.width >= MIN_FOOTER_WIDTH
+    }
+
+    pub fn show_small_results(&self) -> bool {
+        self.area.width < SMALL_RESULTS_WIDTH || self.area.height < SMALL_RESULTS_HEIGHT
     }
 }
 

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -11,9 +11,10 @@ use ratatui::{
 
 use crate::{
     config::Mode,
-    constants::{ASCII_ART, MENU_HEIGHT, MODAL_HEIGHT, MODAL_WIDTH},
+    constants::{ASCII_ART, MENU_HEIGHT, MIN_THEME_PREVIEW_WIDTH, MODAL_HEIGHT, MODAL_WIDTH},
     modal::InputModal,
     termi::Termi,
+    theme::Theme,
     tracker::Status,
     version::VERSION,
 };
@@ -26,7 +27,7 @@ use super::{
         create_show_menu_button, create_styled_typing_text, TermiElement,
     },
     layout::create_layout,
-    utils::{calculate_word_positions, center_div, WordPosition},
+    utils::{apply_horizontal_centering, calculate_word_positions, center_div, WordPosition},
 };
 use crate::modal::ModalContext;
 
@@ -46,6 +47,7 @@ impl TermiClickableRegions {
 /// Main entry point for the rendering
 pub fn draw_ui(frame: &mut Frame, termi: &mut Termi, fps: Option<f64>) -> TermiClickableRegions {
     let mut regions = TermiClickableRegions::default();
+
     let theme = termi.get_current_theme();
     let area = frame.area();
 
@@ -280,9 +282,11 @@ fn render_typing_area(frame: &mut Frame, termi: &Termi, area: Rect) {
     //     - typing/idle
     //     - menu is closed OR menu do not overlap typing area
     //          * this is to be able to preview the cursor if we can see the typing area
+    //     - not in theme menu (to prevent cursor flicker when scrolling through themes)
     let show_cursor = (termi.tracker.status == Status::Idle
         || termi.tracker.status == Status::Typing)
-        && (!termi.menu.is_open() || !estimated_menu_area.intersects(area));
+        && (!termi.menu.is_open() || !estimated_menu_area.intersects(area))
+        && !termi.menu.is_theme_menu();
 
     if show_cursor {
         let offset = cursor_idx.saturating_sub(current_word_pos.start_index);
@@ -409,17 +413,57 @@ fn render_menu(frame: &mut Frame, termi: &Termi, area: Rect) {
     let theme = termi.get_current_theme();
     let menu_state = &termi.menu;
 
-    let menu_height = MENU_HEIGHT.min(area.height);
+    let is_theme_picker = menu_state.is_theme_menu();
 
-    let menu_area = Rect {
-        x: area.x,
-        y: area.y,
-        width: area.width,
-        height: menu_height,
+    let small_width = area.width <= MIN_THEME_PREVIEW_WIDTH;
+    let menu_height = if is_theme_picker && small_width {
+        area.height
+    } else {
+        MENU_HEIGHT.min(area.height)
     };
+
+    // split the menu in two folds if we are in the theme picker
+    let (menu_area, preview_area) = if is_theme_picker && !small_width {
+        let split = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(60), Constraint::Percentage(40)])
+            .split(Rect {
+                x: area.x,
+                y: area.y,
+                width: area.width,
+                height: menu_height,
+            });
+        (split[0], Some(split[1]))
+    } else if is_theme_picker && small_width {
+        let split = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Percentage(60), Constraint::Percentage(40)])
+            .split(Rect {
+                x: area.x,
+                y: area.y,
+                width: area.width,
+                height: menu_height,
+            });
+        (split[0], Some(split[1]))
+    } else {
+        (
+            Rect {
+                x: area.x,
+                y: area.y,
+                width: area.width,
+                height: menu_height,
+            },
+            None,
+        )
+    };
+
     let menu_area = menu_area.intersection(area);
 
     frame.render_widget(Clear, menu_area);
+
+    if let Some(preview) = preview_area {
+        frame.render_widget(Clear, preview);
+    }
 
     let menu_layout = Layout::default()
         .direction(Direction::Vertical)
@@ -499,6 +543,11 @@ fn render_menu(frame: &mut Frame, termi: &Termi, area: Rect) {
 
             frame.render_stateful_widget(scrollbar, scrollbar_area, &mut scrollbar_state);
         }
+
+        // theme preview
+        if let Some(preview_area) = preview_area {
+            render_theme_preview(frame, termi, preview_area);
+        }
     }
 
     let footer_text = create_menu_footer_text(termi);
@@ -513,6 +562,178 @@ fn render_menu(frame: &mut Frame, termi: &Termi, area: Rect) {
         .alignment(Alignment::Left);
 
     frame.render_widget(footer_widget, footer_area);
+}
+
+fn render_theme_preview(frame: &mut Frame, termi: &Termi, area: Rect) {
+    let theme_name = termi
+        .preview_theme_name
+        .as_deref()
+        .unwrap_or(&termi.theme.id);
+
+    let preview_theme = Theme::from_name(theme_name);
+    let theme = &preview_theme;
+
+    // First render a clear background to ensure no color bleed
+    frame.render_widget(Clear, area);
+
+    let preview_block = Block::default()
+        .title(format!(" Theme: {} ", theme_name))
+        .title_alignment(Alignment::Left)
+        .bg(termi.theme.bg())
+        .borders(ratatui::widgets::Borders::ALL)
+        .border_style(Style::default().fg(theme.border()));
+
+    let inner_area = preview_block.inner(area);
+    frame.render_widget(preview_block, area);
+
+    frame.render_widget(
+        Block::default().style(Style::default().bg(theme.bg())),
+        inner_area,
+    );
+
+    let preview_layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // header + spacing
+            Constraint::Length(1), // action bar
+            Constraint::Length(3), // space
+            Constraint::Min(5),    // teset text
+            Constraint::Length(6), // command bar
+        ])
+        .split(inner_area);
+
+    // ------ TITLE ------
+    let header = Paragraph::new("termitype")
+        .style(Style::default().fg(theme.highlight()))
+        .alignment(Alignment::Left);
+
+    frame.render_widget(header, preview_layout[0]);
+
+    // ------ ACTION BAR ------
+    let action_bar_centered = apply_horizontal_centering(preview_layout[1], 80);
+    let action_bar = Line::from(vec![
+        Span::styled("! ", Style::default().fg(theme.highlight())),
+        Span::styled("punctuation ", Style::default().fg(theme.highlight())),
+        Span::styled("# ", Style::default().fg(theme.muted())),
+        Span::styled("numbers ", Style::default().fg(theme.muted())),
+        Span::styled("@ ", Style::default().fg(theme.muted())),
+        Span::styled("symbols ", Style::default().fg(theme.muted())),
+    ])
+    .alignment(Alignment::Center);
+    frame.render_widget(Paragraph::new(action_bar), action_bar_centered);
+
+    // ------ TYPING AREA ------
+    let typing_area_layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(2), // space + lang
+            Constraint::Min(3),    // text
+        ])
+        .split(preview_layout[3]);
+
+    let lang_centered = apply_horizontal_centering(typing_area_layout[0], 80);
+    let lang_indicator = Paragraph::new("english")
+        .style(
+            Style::default()
+                .fg(theme.muted())
+                .add_modifier(Modifier::DIM),
+        )
+        .alignment(Alignment::Center);
+    frame.render_widget(lang_indicator, lang_centered);
+
+    let typing_area_centered = apply_horizontal_centering(typing_area_layout[1], 80);
+    let sample_text = vec![
+        Line::from(vec![
+            Span::styled("terminal ", Style::default().fg(theme.success())),
+            Span::styled("typing ", Style::default().fg(theme.error())),
+            Span::styled(
+                "at its finest",
+                Style::default().fg(theme.fg()).add_modifier(Modifier::DIM),
+            ),
+        ]),
+        Line::from(vec![Span::styled(
+            "brought to you by termitype!",
+            Style::default().fg(theme.fg()).add_modifier(Modifier::DIM),
+        )]),
+    ];
+
+    frame.render_widget(
+        Paragraph::new(sample_text).alignment(Alignment::Center),
+        typing_area_centered,
+    );
+
+    // ------ COMMAND BAR ------
+    let bottom_layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // space
+            Constraint::Length(1), // space
+            Constraint::Length(1), // command bar
+            Constraint::Length(2), // space
+        ])
+        .split(preview_layout[4]);
+
+    let command_bar_centered = apply_horizontal_centering(bottom_layout[2], 80);
+    let command_bar = vec![
+        Line::from(vec![
+            Span::styled(
+                "tab",
+                Style::default()
+                    .fg(theme.highlight())
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" + ", Style::default().fg(theme.muted())),
+            Span::styled(
+                "enter",
+                Style::default()
+                    .fg(theme.highlight())
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" - restart test", Style::default().fg(theme.muted())),
+            // Span::styled(
+            //     "esc",
+            //     Style::default()
+            //         .fg(theme.highlight())
+            //         .add_modifier(Modifier::BOLD),
+            // ),
+            // Span::styled(" - menu", Style::default().fg(theme.muted())),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "ctrl",
+                Style::default()
+                    .fg(theme.highlight())
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" + ", Style::default().fg(theme.muted())),
+            Span::styled(
+                "c",
+                Style::default()
+                    .fg(theme.highlight())
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" or ", Style::default().fg(theme.muted())),
+            Span::styled(
+                "ctrl",
+                Style::default()
+                    .fg(theme.highlight())
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" + ", Style::default().fg(theme.muted())),
+            Span::styled(
+                "z",
+                Style::default()
+                    .fg(theme.highlight())
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" - to quit", Style::default().fg(theme.muted())),
+        ]),
+    ];
+
+    frame.render_widget(
+        Paragraph::new(command_bar).alignment(Alignment::Center),
+        command_bar_centered,
+    );
 }
 
 pub fn render_results_screen(frame: &mut Frame, termi: &mut Termi, area: Rect, is_small: bool) {

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -573,12 +573,9 @@ fn render_theme_preview(frame: &mut Frame, termi: &Termi, area: Rect) {
     let preview_theme = Theme::from_name(theme_name);
     let theme = &preview_theme;
 
-    // First render a clear background to ensure no color bleed
     frame.render_widget(Clear, area);
 
     let preview_block = Block::default()
-        .title(format!(" Theme: {} ", theme_name))
-        .title_alignment(Alignment::Left)
         .bg(termi.theme.bg())
         .borders(ratatui::widgets::Borders::ALL)
         .border_style(Style::default().fg(theme.border()));
@@ -594,20 +591,39 @@ fn render_theme_preview(frame: &mut Frame, termi: &Termi, area: Rect) {
     let preview_layout = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(3), // header + spacing
+            Constraint::Length(4), // header + spacing
             Constraint::Length(1), // action bar
             Constraint::Length(3), // space
-            Constraint::Min(5),    // teset text
+            Constraint::Min(5),    // test text
             Constraint::Length(6), // command bar
         ])
         .split(inner_area);
 
     // ------ TITLE ------
-    let header = Paragraph::new("termitype")
+    let header_area = preview_layout[0];
+    let header_layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1), // p-top
+            Constraint::Length(1), // title
+            Constraint::Min(0),    // space
+        ])
+        .split(header_area);
+
+    let title_layout = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Length(2), // p-left
+            Constraint::Min(10),   // title
+            Constraint::Min(0),    // space
+        ])
+        .split(header_layout[1]);
+
+    let header = Paragraph::new(theme_name)
         .style(Style::default().fg(theme.highlight()))
         .alignment(Alignment::Left);
 
-    frame.render_widget(header, preview_layout[0]);
+    frame.render_widget(header, title_layout[1]);
 
     // ------ ACTION BAR ------
     let action_bar_centered = apply_horizontal_centering(preview_layout[1], 80);

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -284,10 +284,12 @@ fn render_typing_area(frame: &mut Frame, termi: &Termi, area: Rect) {
     //     - typing/idle
     //     - menu is closed OR menu do not overlap typing area
     //          * this is to be able to preview the cursor if we can see the typing area
+    //     - not rendering a modal
     //     - not in theme menu (to prevent cursor flicker when scrolling through themes)
     let show_cursor = (termi.tracker.status == Status::Idle
         || termi.tracker.status == Status::Typing)
         && (!termi.menu.is_open() || !estimated_menu_area.intersects(area))
+        && termi.modal.is_none()
         && !termi.menu.is_theme_menu();
 
     if show_cursor {

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -108,7 +108,7 @@ pub fn draw_ui(frame: &mut Frame, termi: &mut Termi, fps: Option<f64>) -> TermiC
             render_typing_area(frame, termi, layout.section.typing_area);
         }
         Status::Completed => {
-            render_results_screen(frame, termi, area, layout.is_small());
+            render_results_screen(frame, termi, area, layout.show_small_results());
         }
         _ => {
             let mode_bar = create_mode_bar(termi);

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -426,7 +426,7 @@ fn render_menu(frame: &mut Frame, termi: &Termi, area: Rect) {
     let (menu_area, preview_area) = if is_theme_picker && !small_width {
         let split = Layout::default()
             .direction(Direction::Horizontal)
-            .constraints([Constraint::Percentage(60), Constraint::Percentage(40)])
+            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
             .split(Rect {
                 x: area.x,
                 y: area.y,
@@ -437,7 +437,7 @@ fn render_menu(frame: &mut Frame, termi: &Termi, area: Rect) {
     } else if is_theme_picker && small_width {
         let split = Layout::default()
             .direction(Direction::Vertical)
-            .constraints([Constraint::Percentage(60), Constraint::Percentage(40)])
+            .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
             .split(Rect {
                 x: area.x,
                 y: area.y,

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -473,7 +473,7 @@ fn render_menu(frame: &mut Frame, termi: &Termi, area: Rect) {
     let footer_area = menu_layout[1];
 
     if let Some(current_menu) = menu_state.current_menu() {
-        let max_visible = content_area.height.saturating_sub(2) as usize;
+        let max_visible = content_area.height.saturating_sub(3) as usize;
 
         let filtered_items_for_scroll_calc: Vec<_> = if menu_state.is_searching() {
             current_menu.filtered_items(menu_state.search_query())

--- a/src/ui/utils.rs
+++ b/src/ui/utils.rs
@@ -1,4 +1,4 @@
-use ratatui::layout::Rect;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
 
 // TODO: maybe having this file is not entirely needed question mark
 #[derive(Debug, Clone, Copy)]
@@ -19,6 +19,18 @@ pub fn center_div(width: u16, height: u16, parent: Rect) -> Rect {
     let y = parent.y + (parent_h.saturating_sub(height)) / 2;
 
     Rect::new(x, y, width, height)
+}
+
+pub fn apply_horizontal_centering(area: Rect, width_percent: u16) -> Rect {
+    let padding = (100 - width_percent) / 2;
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage(padding),
+            Constraint::Percentage(width_percent),
+            Constraint::Percentage(padding),
+        ])
+        .split(area)[1]
 }
 
 pub fn calculate_word_positions(text: &str, available_width: usize) -> Vec<WordPosition> {


### PR DESCRIPTION
Closes: #56  

This PR adds the ability to have preview windows on the menu. Right now we are only using it for Theme Previews but eventually could be useful for showing previews of ascii art for example #55 .

This PR also improves the theme loading and caching system (bebdf5e7ee05374ecc4bbd79ead97c40fa002f65)