### PR TITLE
fix: extremely wide area on large screen sizes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+      {
+          "name": "Debug",
+          "type": "lldb",
+          "request": "launch",
+          "program": "${workspaceFolder}/target/debug/termitype",
+          "args": [
+            "--color-mode",
+            "truecolor"
+
+          ],
+          "cwd": "${workspaceFolder}",
+          "preLaunchTask": "cargo build"
+      },
+      {
+          "name": "Release",
+          "type": "lldb",
+          "request": "launch",
+          "program": "${workspaceFolder}/target/release/termitype",
+          "args": [
+            "--color-mode",
+            "truecolor"
+          ],
+          "cwd": "${workspaceFolder}",
+          "preLaunchTask": "cargo build release"
+      }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,45 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+      {
+          "label": "cargo build",
+          "dependsOn": [
+              "cargo build"
+          ]
+      },
+      {
+          "label": "cargo build release",
+          "dependsOn": [
+              "cargo build release"
+          ]
+      },
+
+      {
+          "label": "cargo build",
+          "type": "cargo",
+          "command": "build",
+          "args": [
+          ],
+          "problemMatcher": [
+              "$rustc"
+          ],
+          "options": {
+              "cwd": "${workspaceFolder}"
+          },
+      },
+      {
+          "label": "cargo build",
+          "type": "cargo",
+          "command": "build",
+          "args": [
+              "--release"
+          ],
+          "problemMatcher": [
+              "$rustc"
+          ],
+          "options": {
+              "cwd": "${workspaceFolder}"
+          },
+      }
+  ]
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ include = [
 [profile.release]
 debug = true
 
+[profile.dev]
+debug = true
+
 [dependencies]
 anyhow = "1.0.97"
 clap = { version = "4.5.31", features = ["derive"] }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -62,7 +62,7 @@ pub const TOP_AREA_HEIGHT: u16 = HEADER_HEIGHT + ACTION_BAR_HEIGHT;
 
 // mid area
 pub const MODE_BAR_HEIGHT: u16 = 2;
-pub const TYPING_AREA_WIDTH_PERCENT: u16 = 80;
+pub const TYPING_AREA_WIDTH: u16 = 80;
 
 // bottom area
 pub const COMMAND_BAR_HEIGHT: u16 = 3;

--- a/src/input.rs
+++ b/src/input.rs
@@ -420,19 +420,23 @@ fn execute_menu_action(action: MenuInputAction, state: &mut Termi) -> Action {
                     }
                     MenuAction::ChangeMode(mode) => {
                         state.config.change_mode(mode, None);
+                        state.start();
                     }
                     MenuAction::ChangeTime(time) => {
                         state
                             .config
                             .change_mode(ModeType::Time, Some(time as usize));
+                        state.start();
                     }
                     MenuAction::ChangeWordCount(count) => {
                         state.config.change_mode(ModeType::Words, Some(count));
+                        state.start();
                     }
                     MenuAction::ChangeVisibleLineCount(count) => {
                         state
                             .config
                             .change_visible_lines(count.try_into().unwrap_or(DEFAULT_LINE_COUNT));
+                        state.start();
                     }
                     MenuAction::ChangeTheme(theme_name) => {
                         state.config.change_theme(&theme_name);

--- a/src/input.rs
+++ b/src/input.rs
@@ -257,12 +257,7 @@ pub fn process_action(action: Action, state: &mut Termi) -> Action {
             state.tracker.backspace();
             Action::None
         }
-        Action::Menu(menu_action) => {
-            // NOTE: This might be wasteful
-            state.update_preview_theme();
-            state.update_preview_cursor();
-            execute_menu_action(menu_action, state)
-        }
+        Action::Menu(menu_action) => execute_menu_action(menu_action, state),
         Action::Start => {
             state.start();
             Action::None
@@ -389,6 +384,7 @@ fn execute_menu_action(action: MenuInputAction, state: &mut Termi) -> Action {
                 )
                 .ok();
             }
+            state.clear_previews();
             Action::None
         }
         MenuInputAction::Select => {
@@ -505,6 +501,7 @@ fn execute_menu_action(action: MenuInputAction, state: &mut Termi) -> Action {
         MenuInputAction::Close => {
             state.tracker.resume();
             state.menu.close();
+            state.clear_previews();
             Action::None
         }
     }

--- a/src/termi.rs
+++ b/src/termi.rs
@@ -199,6 +199,11 @@ impl Termi {
         self.preview_theme.as_ref().unwrap_or(&self.theme)
     }
 
+    pub fn clear_previews(&mut self) {
+        self.preview_theme = None;
+        self.preview_cursor = None
+    }
+
     pub fn update_preview_theme(&mut self) {
         if let Some(theme_name) = self.menu.get_preview_theme() {
             self.preview_theme_name = Some(theme_name.clone());

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -3,7 +3,7 @@ use crate::{
         ACTION_BAR_HEIGHT, BOTTOM_AREA_HEIGHT, BOTTOM_PADDING, COMMAND_BAR_HEIGHT, FOOTER_HEIGHT,
         HEADER_HEIGHT, MIN_FOOTER_WIDTH, MIN_TERM_HEIGHT, MIN_TERM_WIDTH, MODE_BAR_HEIGHT,
         SMALL_RESULTS_HEIGHT, SMALL_RESULTS_WIDTH, SMALL_TERM_HEIGHT, SMALL_TERM_WIDTH,
-        TOP_AREA_HEIGHT, TYPING_AREA_WIDTH_PERCENT,
+        TOP_AREA_HEIGHT, TYPING_AREA_WIDTH,
     },
     termi::Termi,
 };
@@ -98,7 +98,7 @@ pub fn create_layout(area: Rect, termi: &Termi) -> TermiLayout {
         .split(top_area);
 
     let header_section = top_chunk[0];
-    let action_bar_section = apply_horizontal_centering(top_chunk[1], TYPING_AREA_WIDTH_PERCENT);
+    let action_bar_section = apply_horizontal_centering(top_chunk[1], TYPING_AREA_WIDTH);
 
     // ==== MIDDLE ====
     let mid_outer_chunk = Layout::default()
@@ -118,8 +118,8 @@ pub fn create_layout(area: Rect, termi: &Termi) -> TermiLayout {
         ])
         .split(mid_outer_chunk);
 
-    let mode_bar_section = apply_horizontal_centering(mid_chunk[0], TYPING_AREA_WIDTH_PERCENT);
-    let typing_area_section = apply_horizontal_centering(mid_chunk[1], TYPING_AREA_WIDTH_PERCENT);
+    let mode_bar_section = apply_horizontal_centering(mid_chunk[0], TYPING_AREA_WIDTH);
+    let typing_area_section = apply_horizontal_centering(mid_chunk[1], TYPING_AREA_WIDTH);
 
     // ==== BOTTOM ====
     let bot_chunks = Layout::default()
@@ -131,8 +131,8 @@ pub fn create_layout(area: Rect, termi: &Termi) -> TermiLayout {
         ])
         .split(bot_area);
 
-    let command_bar_section = apply_horizontal_centering(bot_chunks[0], TYPING_AREA_WIDTH_PERCENT);
-    let footer_section = apply_horizontal_centering(bot_chunks[2], TYPING_AREA_WIDTH_PERCENT);
+    let command_bar_section = apply_horizontal_centering(bot_chunks[0], TYPING_AREA_WIDTH);
+    let footer_section = apply_horizontal_centering(bot_chunks[2], TYPING_AREA_WIDTH);
 
     let section = TermiSection {
         header: header_section,


### PR DESCRIPTION
This PR fixes the problem referenced on #60 with wider terminal screen sizes

- The above pane reflects the new changes (wrap at 80) and the pane below the prior to the changes.
		- this makes it easier to type on wider screens (for those that want that....)
![image](https://github.com/user-attachments/assets/8c83fcef-d886-44da-bba1-6a1255eef5b1)



Closes: #60