### PR TITLE
fix: running out of words in time mode

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -193,7 +193,10 @@ pub fn print_language_list() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{config::Config, constants::MAX_CUSTOM_TIME};
+    use crate::{
+        config::Config,
+        constants::{MAX_CUSTOM_TIME, WPS_TARGET},
+    };
 
     fn create_builder() -> Builder {
         Builder::new()
@@ -245,26 +248,25 @@ mod tests {
         // NOTE: This test assumes a user typing at 300wpm which is equivalent to 5 words per second (300/60)
         let mut builder = create_builder();
         let mut config = Config::default();
-        const WPS: usize = 5;
 
         // 10 seconds test duration
         config.change_mode(crate::config::ModeType::Time, Some(10));
         let test = builder.generate_test(&config);
         let words: Vec<&str> = test.split_whitespace().collect();
 
-        assert!(words.len() >= WPS * 10);
+        assert!(words.len() >= WPS_TARGET as usize * 10);
 
         // 60 seconds test duration
         config.change_mode(crate::config::ModeType::Time, Some(60));
         let test = builder.generate_test(&config);
         let words: Vec<&str> = test.split_whitespace().collect();
-        assert!(words.len() >= WPS * 60);
+        assert!(words.len() >= WPS_TARGET as usize * 60);
 
         // 120 seconds test duration
         config.change_mode(crate::config::ModeType::Time, Some(120));
         let test = builder.generate_test(&config);
         let words: Vec<&str> = test.split_whitespace().collect();
-        assert!(words.len() >= WPS * 120);
+        assert!(words.len() >= WPS_TARGET as usize * 120);
 
         // MAX_CUSTOM_TIME seconds test duration
         config.change_mode(
@@ -273,6 +275,6 @@ mod tests {
         );
         let test = builder.generate_test(&config);
         let words: Vec<&str> = test.split_whitespace().collect();
-        assert!(words.len() >= WPS * MAX_CUSTOM_TIME as usize);
+        assert!(words.len() >= WPS_TARGET as usize * MAX_CUSTOM_TIME as usize);
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -193,7 +193,7 @@ pub fn print_language_list() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::Config;
+    use crate::{config::Config, constants::MAX_CUSTOM_TIME};
 
     fn create_builder() -> Builder {
         Builder::new()
@@ -238,5 +238,41 @@ mod tests {
 
         let unique_words: std::collections::HashSet<&str> = words.iter().copied().collect();
         assert!(unique_words.len() > 1);
+    }
+
+    #[test]
+    fn test_generates_enough_words_in_time_mode() {
+        // NOTE: This test assumes a user typing at 300wpm which is equivalent to 5 words per second (300/60)
+        let mut builder = create_builder();
+        let mut config = Config::default();
+        const WPS: usize = 5;
+
+        // 10 seconds test duration
+        config.change_mode(crate::config::ModeType::Time, Some(10));
+        let test = builder.generate_test(&config);
+        let words: Vec<&str> = test.split_whitespace().collect();
+
+        assert!(words.len() >= WPS * 10);
+
+        // 60 seconds test duration
+        config.change_mode(crate::config::ModeType::Time, Some(60));
+        let test = builder.generate_test(&config);
+        let words: Vec<&str> = test.split_whitespace().collect();
+        assert!(words.len() >= WPS * 60);
+
+        // 120 seconds test duration
+        config.change_mode(crate::config::ModeType::Time, Some(120));
+        let test = builder.generate_test(&config);
+        let words: Vec<&str> = test.split_whitespace().collect();
+        assert!(words.len() >= WPS * 120);
+
+        // MAX_CUSTOM_TIME seconds test duration
+        config.change_mode(
+            crate::config::ModeType::Time,
+            Some(MAX_CUSTOM_TIME as usize),
+        );
+        let test = builder.generate_test(&config);
+        let words: Vec<&str> = test.split_whitespace().collect();
+        assert!(words.len() >= WPS * MAX_CUSTOM_TIME as usize);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,7 @@ use crate::{
     builder::Builder,
     constants::{
         DEFAULT_CURSOR_STYLE, DEFAULT_LANGUAGE, DEFAULT_LINE_COUNT, DEFAULT_THEME,
-        DEFAULT_TIME_MODE_DURATION, DEFAULT_WORD_MODE_COUNT,
+        DEFAULT_TIME_MODE_DURATION, DEFAULT_WORD_MODE_COUNT, WPS_TARGET,
     },
     persistence::Persistence,
     theme::{ColorSupport, Theme, ThemeLoader},
@@ -360,14 +360,13 @@ impl Config {
 
     /// Resolves the test word count based on current configuration.
     pub fn resolve_word_count(&self) -> usize {
-        const WORDS_PER_SECOND: f64 = 5.0;
         if let Some(word_count) = self.word_count {
             word_count
         } else if let Some(duration) = self.time {
-            let estimated_wc = (duration as f64 * WORDS_PER_SECOND).ceil() as usize;
+            let estimated_wc = (duration as f64 * WPS_TARGET).ceil() as usize;
             std::cmp::max(estimated_wc, DEFAULT_WORD_MODE_COUNT)
         } else {
-            let estimated_wc = (DEFAULT_WORD_MODE_COUNT as f64 * WORDS_PER_SECOND).ceil() as usize;
+            let estimated_wc = (DEFAULT_WORD_MODE_COUNT as f64 * WPS_TARGET).ceil() as usize;
             std::cmp::max(estimated_wc, DEFAULT_WORD_MODE_COUNT)
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -360,9 +360,15 @@ impl Config {
 
     /// Resolves the test word count based on current configuration.
     pub fn resolve_word_count(&self) -> usize {
-        match (self.time, self.word_count) {
-            (None, Some(count)) => count,
-            _ => DEFAULT_WORD_MODE_COUNT,
+        const WORDS_PER_SECOND: f64 = 5.0;
+        if let Some(word_count) = self.word_count {
+            word_count
+        } else if let Some(duration) = self.time {
+            let estimated_wc = (duration as f64 * WORDS_PER_SECOND).ceil() as usize;
+            std::cmp::max(estimated_wc, DEFAULT_WORD_MODE_COUNT)
+        } else {
+            let estimated_wc = (DEFAULT_WORD_MODE_COUNT as f64 * WORDS_PER_SECOND).ceil() as usize;
+            std::cmp::max(estimated_wc, DEFAULT_WORD_MODE_COUNT)
         }
     }
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -75,7 +75,7 @@ pub const BOTTOM_AREA_HEIGHT: u16 = COMMAND_BAR_HEIGHT + BOTTOM_PADDING + FOOTER
 
 // Modals
 pub const MIN_CUSTOM_TIME: u16 = 1;
-pub const MAX_CUSTOM_TIME: u16 = 100;
+pub const MAX_CUSTOM_TIME: u16 = 300; // 5 minutes
 
 pub const MIN_CUSTOM_WORD_COUNT: u16 = 1;
 pub const MAX_CUSTOM_WORD_COUNT: u16 = 5000;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -8,6 +8,9 @@ pub const DEFAULT_THEME: &str = "tokyonight";
 pub const DEFAULT_TIME_MODE_DURATION: usize = 30;
 pub const DEFAULT_TIME_DURATION_LIST: [usize; 4] = [15, 30, 60, 120];
 
+// This is the target wps that we use. This assument as constant 350wpm as our upper bound
+pub const WPS_TARGET: f64 = 6.0;
+
 pub const DEFAULT_WORD_MODE_COUNT: usize = 50;
 pub const DEFAULT_WORD_COUNT_LIST: [usize; 4] = [10, 25, 50, 100];
 


### PR DESCRIPTION
This PR solves the issues of typing relatively fast (> 115 wpm) on `Time` mode, especially on (120s), caused the test to run out of words.

Before this PR we generated at most 50 words per test (assuming `Time` mode as `Words` mode sets it's own word count target). This penalized fast typers as the almost always ended running out of words.J


The fix for this is simple, at least for now, assume an upper bound of 350wpm. We ensure to always generate enough words for users typing at 350wpm.

Ideally, test words would be generated lazily at per need basis, but this is good enough for now.

Closes: #63