### PR TITLE
Improve Results screen

### DIFF
--- a/assets/themes/Serika Dark
+++ b/assets/themes/Serika Dark
@@ -1,8 +1,8 @@
-palette = 0=#323437
+palette = 0=#2c2e31
 palette = 1=#ca4754
 palette = 2=#ffffff
 palette = 3=#e2b714
-palette = 4=#646669
+palette = 4=#56b6c2
 palette = 5=#e2b714
 palette = 6=#e2b714
 palette = 7=#a9aab0

--- a/assets/themes/termitype-dark
+++ b/assets/themes/termitype-dark
@@ -14,7 +14,7 @@ palette = 13=#C586C0
 palette = 14=#FFFFFF
 palette = 15=#FFFFFF
 background = #000000
-foreground = #FFFFFF
+foreground = #6B7279
 cursor-color = #FF5D00
 cursor-text = #000000
 selection-background = #484848

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -60,6 +60,10 @@ pub enum TermiAction {
     // === Previews ===
     ApplyPreview(PreviewType),
     ClearPreview,
+
+    // === Debug Helper Actions ===
+    #[cfg(debug_assertions)]
+    DebugToggleResults,
 }
 
 // ============== MENU ==============
@@ -343,5 +347,10 @@ pub fn process_action(action: TermiAction, termi: &mut Termi) {
                 .ok();
             }
         }
+        #[cfg(debug_assertions)]
+        TermiAction::DebugToggleResults => match termi.tracker.status {
+            Status::Completed => termi.start(),
+            _ => termi.tracker.complete(),
+        },
     }
 }

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -21,6 +21,7 @@ pub enum TermiAction {
 
     // === State ===
     Start,
+    Redo,
     TogglePause,
 
     // === Typing ===
@@ -194,6 +195,7 @@ pub fn process_action(action: TermiAction, termi: &mut Termi) {
         TermiAction::Quit => {} // already handled as an inmediate action above
         TermiAction::NoOp => {}
         TermiAction::Start => termi.start(),
+        TermiAction::Redo => termi.redo(),
         TermiAction::TogglePause => {
             if termi.tracker.status == Status::Paused {
                 termi.tracker.resume();

--- a/src/config.rs
+++ b/src/config.rs
@@ -96,6 +96,10 @@ pub struct Config {
     #[arg(long = "show-fps")]
     pub show_fps: bool,
 
+    /// Show results with only two colors
+    #[arg(long = "monochromatic-results")]
+    pub monocrhomatic_results: bool,
+
     /// Stores the persistence of the game. Set automatically.
     #[arg(skip)]
     persistent: Option<Persistence>,
@@ -141,6 +145,7 @@ impl Default for Config {
             list_languages: false,
             version: false,
             show_fps: false,
+            monocrhomatic_results: false,
             #[cfg(debug_assertions)]
             debug: false,
             persistent: None,

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -52,7 +52,8 @@ pub const SMALL_RESULTS_WIDTH: u16 = 60;
 pub const SMALL_RESULTS_HEIGHT: u16 = 20;
 
 pub const MIN_TERM_HEIGHT: u16 = 15;
-pub const MIN_TERM_WIDTH: u16 = 35;
+pub const MIN_TERM_WIDTH: u16 = 25;
+
 pub const MIN_FOOTER_WIDTH: u16 = 55;
 pub const MIN_THEME_PREVIEW_WIDTH: u16 = 60;
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -18,6 +18,7 @@ pub enum InputMode {
 
 #[derive(Default)]
 pub struct InputHandler {
+    // FIXME(ema): this is duplicated on @termi.rs
     last_key_code: Option<KeyCode>,
     pending_accent: Option<char>,
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -19,14 +19,14 @@ pub enum InputMode {
 #[derive(Default)]
 pub struct InputHandler {
     // FIXME(ema): this is duplicated on @termi.rs
-    last_key_code: Option<KeyCode>,
+    last_keycode: Option<KeyCode>,
     pending_accent: Option<char>,
 }
 
 impl InputHandler {
     pub fn new() -> Self {
         InputHandler {
-            last_key_code: None,
+            last_keycode: None,
             pending_accent: None,
         }
     }
@@ -46,16 +46,21 @@ impl InputHandler {
         }
     }
 
-    pub fn handle_input(&mut self, event: KeyEvent, mode: InputMode) -> TermiAction {
-        let last_key_cache = self.last_key_code;
-        let curr_key_code = event.code;
-
+    pub fn handle_input(
+        &mut self,
+        event: KeyEvent,
+        last_event: Option<KeyEvent>,
+        mode: InputMode,
+    ) -> TermiAction {
         if self.is_quit_sequence(&event) {
             return TermiAction::Quit;
         }
 
-        if self.is_restart_sequence(&event.code, &last_key_cache) {
-            return TermiAction::Start;
+        if let Some(last_ev) = last_event {
+            self.last_keycode = Some(last_ev.code);
+            if self.is_restart_sequence(&event.code, &last_ev.code) {
+                return TermiAction::Start;
+            }
         }
 
         #[cfg(debug_assertions)]
@@ -70,7 +75,6 @@ impl InputHandler {
             InputMode::Menu { is_searching } => self.handle_menu_input(event, is_searching),
         };
 
-        self.last_key_code = Some(curr_key_code);
         action
     }
 
@@ -180,7 +184,7 @@ impl InputHandler {
                 (KeyCode::Char('g'), KeyModifiers::NONE) => {
                     // this is fugly
                     let mut phone_home = false;
-                    if let Some(code) = self.last_key_code {
+                    if let Some(code) = self.last_keycode {
                         log_debug!("Code: {}.... result = {}", code, code == KeyCode::Char('g'));
                         if code == KeyCode::Char('g') {
                             phone_home = true
@@ -212,8 +216,8 @@ impl InputHandler {
             && event.modifiers.contains(KeyModifiers::CONTROL)
     }
 
-    fn is_restart_sequence(&self, current_key: &KeyCode, last_key: &Option<KeyCode>) -> bool {
-        matches!(last_key, Some(KeyCode::Tab)) && matches!(current_key, KeyCode::Enter)
+    fn is_restart_sequence(&self, current_key: &KeyCode, last_key: &KeyCode) -> bool {
+        matches!(last_key, KeyCode::Tab) && matches!(current_key, KeyCode::Enter)
     }
 
     // TODO: this is dumb, i think (?). There has to be a better way to handle this
@@ -227,5 +231,166 @@ impl InputHandler {
             'n' => Some('ñ'),
             _ => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    fn create_key_event(code: KeyCode, modifiers: KeyModifiers) -> KeyEvent {
+        KeyEvent::new(code, modifiers)
+    }
+
+    #[test]
+    fn test_default_state() {
+        let handler = InputHandler::new();
+        assert!(handler.last_keycode.is_none());
+        assert!(handler.pending_accent.is_none());
+    }
+
+    #[test]
+    fn test_quit_sequence() {
+        let handler = InputHandler::new();
+
+        // <ctrl-c>
+        let event = create_key_event(KeyCode::Char('c'), KeyModifiers::CONTROL);
+        assert!(handler.is_quit_sequence(&event));
+
+        // <ctrl+z>
+        let event = create_key_event(KeyCode::Char('z'), KeyModifiers::CONTROL);
+        assert!(handler.is_quit_sequence(&event));
+
+        // non-quit seq
+        let event = create_key_event(KeyCode::Char('c'), KeyModifiers::NONE);
+        assert!(!handler.is_quit_sequence(&event));
+    }
+
+    #[test]
+    fn test_restart_sequence() {
+        let handler = InputHandler::new();
+
+        assert!(handler.is_restart_sequence(&KeyCode::Enter, &KeyCode::Tab));
+        assert!(!handler.is_restart_sequence(&KeyCode::Enter, &KeyCode::Enter));
+        assert!(!handler.is_restart_sequence(&KeyCode::Tab, &KeyCode::Tab));
+    }
+
+    #[test]
+    fn test_typing_input() {
+        let mut handler = InputHandler::new();
+
+        let event = create_key_event(KeyCode::Char('a'), KeyModifiers::NONE);
+        assert_eq!(handler.handle_typing_input(event), TermiAction::Input('a'));
+
+        let event = create_key_event(KeyCode::Backspace, KeyModifiers::NONE);
+        assert_eq!(handler.handle_typing_input(event), TermiAction::Backspace);
+
+        let event = create_key_event(KeyCode::Esc, KeyModifiers::NONE);
+        assert_eq!(handler.handle_typing_input(event), TermiAction::TogglePause);
+    }
+
+    #[test]
+    fn test_results_input() {
+        let mut handler = InputHandler::new();
+
+        // <r>
+        let event = create_key_event(KeyCode::Char('r'), KeyModifiers::NONE);
+        assert_eq!(handler.handle_results_input(event), TermiAction::Redo);
+
+        // <n>
+        let event = create_key_event(KeyCode::Char('n'), KeyModifiers::NONE);
+        assert_eq!(handler.handle_results_input(event), TermiAction::Start);
+
+        // <q>
+        let event = create_key_event(KeyCode::Char('q'), KeyModifiers::NONE);
+        assert_eq!(handler.handle_results_input(event), TermiAction::Quit);
+
+        // <esc>
+        let event = create_key_event(KeyCode::Esc, KeyModifiers::NONE);
+        assert_eq!(
+            handler.handle_results_input(event),
+            TermiAction::TogglePause
+        );
+    }
+
+    #[test]
+    fn test_menu_search_input() {
+        let handler = InputHandler::new();
+
+        let event = create_key_event(KeyCode::Char('a'), KeyModifiers::NONE);
+        assert_eq!(
+            handler.handle_menu_input(event, true),
+            TermiAction::MenuSearch(MenuSearchAction::Input('a'))
+        );
+
+        let event = create_key_event(KeyCode::Up, KeyModifiers::NONE);
+        assert_eq!(
+            handler.handle_menu_input(event, true),
+            TermiAction::MenuNavigate(MenuNavAction::Up)
+        );
+
+        // vim nav
+        let event = create_key_event(KeyCode::Char('j'), KeyModifiers::CONTROL);
+        assert_eq!(
+            handler.handle_menu_input(event, true),
+            TermiAction::MenuNavigate(MenuNavAction::Down)
+        );
+    }
+
+    #[test]
+    fn test_menu_navigation() {
+        let handler = InputHandler::new();
+
+        let event = create_key_event(KeyCode::Up, KeyModifiers::NONE);
+        assert_eq!(
+            handler.handle_menu_input(event, false),
+            TermiAction::MenuNavigate(MenuNavAction::Up)
+        );
+
+        let event = create_key_event(KeyCode::Char('j'), KeyModifiers::NONE);
+        assert_eq!(
+            handler.handle_menu_input(event, false),
+            TermiAction::MenuNavigate(MenuNavAction::Down)
+        );
+
+        let event = create_key_event(KeyCode::Enter, KeyModifiers::NONE);
+        assert_eq!(
+            handler.handle_menu_input(event, false),
+            TermiAction::MenuSelect
+        );
+
+        let event = create_key_event(KeyCode::Esc, KeyModifiers::NONE);
+        assert_eq!(
+            handler.handle_menu_input(event, false),
+            TermiAction::MenuNavigate(MenuNavAction::Back)
+        );
+    }
+
+    #[test]
+    fn test_modal_input() {
+        let handler = InputHandler::new();
+
+        // <a>
+        let event = create_key_event(KeyCode::Char('a'), KeyModifiers::NONE);
+        assert_eq!(
+            handler.handle_modal_input(event),
+            TermiAction::ModalInput('a')
+        );
+
+        // <esc>
+        let event = create_key_event(KeyCode::Esc, KeyModifiers::NONE);
+        assert_eq!(handler.handle_modal_input(event), TermiAction::ModalClose);
+
+        // <enter>
+        let event = create_key_event(KeyCode::Enter, KeyModifiers::NONE);
+        assert_eq!(handler.handle_modal_input(event), TermiAction::ModalConfirm);
+
+        // <backspace>
+        let event = create_key_event(KeyCode::Backspace, KeyModifiers::NONE);
+        assert_eq!(
+            handler.handle_modal_input(event),
+            TermiAction::ModalBackspace
+        );
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -76,7 +76,7 @@ impl InputHandler {
     #[cfg(debug_assertions)]
     fn handle_debug_input(&mut self, event: KeyEvent) -> Option<TermiAction> {
         match (event.code, event.modifiers) {
-            (KeyCode::F(4), _) => Some(TermiAction::DebugToggleResults),
+            (KeyCode::F(10), _) => Some(TermiAction::DebugToggleResults),
             _ => None,
         }
     }
@@ -113,6 +113,10 @@ impl InputHandler {
             (KeyCode::Char('r'), KeyModifiers::NONE) => TermiAction::Redo,
             (KeyCode::Char('n'), KeyModifiers::NONE) => TermiAction::Start,
             (KeyCode::Char('q'), KeyModifiers::NONE) => TermiAction::Quit,
+            (KeyCode::Esc, KeyModifiers::NONE) => {
+                self.pending_accent = None;
+                TermiAction::TogglePause
+            }
             _ => TermiAction::NoOp,
         }
     }

--- a/src/input.rs
+++ b/src/input.rs
@@ -67,14 +67,12 @@ impl InputHandler {
             return debug_action;
         }
 
-        let action = match mode {
+        match mode {
             InputMode::Typing => self.handle_typing_input(event),
             InputMode::Results => self.handle_results_input(event),
             InputMode::Modal => self.handle_modal_input(event),
             InputMode::Menu { is_searching } => self.handle_menu_input(event, is_searching),
-        };
-
-        action
+        }
     }
 
     #[cfg(debug_assertions)]

--- a/src/input.rs
+++ b/src/input.rs
@@ -52,6 +52,11 @@ impl InputHandler {
             return TermiAction::Start;
         }
 
+        #[cfg(debug_assertions)]
+        if let Some(debug_action) = self.handle_debug_input(event) {
+            return debug_action;
+        }
+
         let action = match mode {
             InputMode::Typing => self.handle_typing_input(event),
             InputMode::Modal => self.handle_modal_input(event),
@@ -60,6 +65,14 @@ impl InputHandler {
 
         self.last_key_code = Some(curr_key_code);
         action
+    }
+
+    #[cfg(debug_assertions)]
+    fn handle_debug_input(&mut self, event: KeyEvent) -> Option<TermiAction> {
+        match (event.code, event.modifiers) {
+            (KeyCode::F(4), _) => Some(TermiAction::DebugToggleResults),
+            _ => None,
+        }
     }
 
     fn handle_typing_input(&mut self, event: KeyEvent) -> TermiAction {

--- a/src/input.rs
+++ b/src/input.rs
@@ -18,7 +18,6 @@ pub enum InputMode {
 
 #[derive(Default)]
 pub struct InputHandler {
-    // FIXME(ema): this is duplicated on @termi.rs
     last_keycode: Option<KeyCode>,
     pending_accent: Option<char>,
 }

--- a/src/termi.rs
+++ b/src/termi.rs
@@ -84,6 +84,15 @@ impl Termi {
         self.menu = menu;
     }
 
+    /// Redo Redo - Taeha circa 2020
+    pub fn redo(&mut self) {
+        let menu = self.menu.clone();
+        let words = self.words.clone();
+
+        self.tracker = Tracker::new(&self.config, words);
+        self.menu = menu;
+    }
+
     pub fn current_theme(&self) -> &Theme {
         self.preview_theme.as_ref().unwrap_or(&self.theme)
     }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -33,11 +33,11 @@ pub enum ThemeColor {
     Foreground,     // Default Text
     Muted,          // Dimmed Text
     Accent,         // Carets and Arrows
+    Info,           // Information
     Highlight,      // Selected items
     Success,        // Correct Words
     Error,          // Wrong Words
     Warning,        // Warning messages
-    Border,         // UI Borders
     Cursor,         // Cursor Color
     CursorText,     // Text under Cursor
     SelectionBg,    // Text Selection Background
@@ -171,11 +171,11 @@ impl Theme {
                 Color::White,       // Foreground
                 Color::Gray,        // Muted
                 Color::Cyan,        // Accent
+                Color::LightCyan,   // Info
                 Color::LightGreen,  // Highlight
                 Color::Green,       // Success
                 Color::Red,         // Error
                 Color::LightYellow, // Warning
-                Color::DarkGray,    // Border
                 Color::White,       // Cursor
                 Color::Black,       // CursorText
                 Color::DarkGray,    // SelectionBg
@@ -281,6 +281,10 @@ impl Theme {
         self.colors[ThemeColor::Accent as usize]
     }
 
+    pub fn info(&self) -> Color {
+        self.colors[ThemeColor::Info as usize]
+    }
+
     pub fn highlight(&self) -> Color {
         self.colors[ThemeColor::Highlight as usize]
     }
@@ -298,7 +302,7 @@ impl Theme {
     }
 
     pub fn border(&self) -> Color {
-        self.colors[ThemeColor::Border as usize]
+        self.colors[ThemeColor::Muted as usize]
     }
 
     pub fn cursor(&self) -> Color {
@@ -420,7 +424,9 @@ impl ThemeLoader {
         colors[ThemeColor::Background as usize] = parse_color("background")?;
         colors[ThemeColor::Foreground as usize] = parse_color("foreground")?;
         colors[ThemeColor::Muted as usize] = parse_color("palette7")?;
-        colors[ThemeColor::Accent as usize] = parse_color("palette14")?;
+        colors[ThemeColor::Warning as usize] = parse_color("palette3")?;
+        colors[ThemeColor::Accent as usize] = parse_color("palette5")?;
+        colors[ThemeColor::Info as usize] = parse_color("palette4")?;
         colors[ThemeColor::Highlight as usize] = parse_color("palette6")?;
         colors[ThemeColor::Success as usize] = parse_color("palette2")?;
         colors[ThemeColor::Error as usize] = parse_color("palette1")?;

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -329,8 +329,8 @@ impl Tracker {
     }
 
     pub fn complete(&mut self) {
-        let start_time = self.time_started.unwrap();
-        let end_time = self.time_end.unwrap();
+        let start_time = self.time_started.unwrap_or(Instant::now());
+        let end_time = self.time_end.unwrap_or(Instant::now());
         self.time_remaining = Some(Duration::from_secs(0));
         self.completion_time = Some(end_time.duration_since(start_time).as_secs_f64());
         self.status = Status::Completed;

--- a/src/ui/elements.rs
+++ b/src/ui/elements.rs
@@ -303,8 +303,7 @@ pub fn create_typing_area<'a>(
         lines.push(Line::from(current_line_spans));
     }
 
-    let text = Text::from(lines);
-    text
+    Text::from(lines)
 }
 
 pub fn create_command_bar(termi: &Termi) -> Vec<TermiElement> {

--- a/src/ui/elements.rs
+++ b/src/ui/elements.rs
@@ -414,12 +414,14 @@ pub fn create_minimal_size_warning(termi: &Termi, width: u16, height: u16) -> Ve
     let theme = termi.current_theme();
     let warning_lines = vec![
         Line::from(Span::styled(
-            "! too small",
+            "! size too small",
             Style::default().fg(theme.error()),
         )),
         Line::from(""),
+        Line::from("Current:"),
+        Line::from(""),
         Line::from(vec![
-            Span::styled("Current: (", Style::default().fg(theme.muted())),
+            Span::styled("Width = ", Style::default().fg(theme.muted())),
             Span::styled(
                 format!("{}", width),
                 Style::default().fg(if width < MIN_TERM_WIDTH {
@@ -428,7 +430,7 @@ pub fn create_minimal_size_warning(termi: &Termi, width: u16, height: u16) -> Ve
                     theme.success()
                 }),
             ),
-            Span::styled("x", Style::default().fg(theme.muted())),
+            Span::styled(" Height = ", Style::default().fg(theme.muted())),
             Span::styled(
                 format!("{}", height),
                 Style::default().fg(if height < MIN_TERM_HEIGHT {
@@ -437,12 +439,22 @@ pub fn create_minimal_size_warning(termi: &Termi, width: u16, height: u16) -> Ve
                     theme.success()
                 }),
             ),
-            Span::styled(")", Style::default().fg(theme.muted())),
         ]),
-        Line::from(Span::styled(
-            format!("Needed: ({}x{})", MIN_TERM_WIDTH, MIN_TERM_HEIGHT),
-            Style::default().fg(theme.muted()),
-        )),
+        Line::from(""),
+        Line::from("Needed:"),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("Width = ", Style::default().fg(theme.muted())),
+            Span::styled(
+                format!("{}", MIN_TERM_WIDTH),
+                Style::default().fg(theme.muted()),
+            ),
+            Span::styled(" Height = ", Style::default().fg(theme.muted())),
+            Span::styled(
+                format!("{}", MIN_TERM_HEIGHT),
+                Style::default().fg(theme.muted()),
+            ),
+        ]),
     ];
     let text = Text::from(warning_lines).alignment(Alignment::Center);
     vec![TermiElement::new(text, false, None)]

--- a/src/ui/elements.rs
+++ b/src/ui/elements.rs
@@ -3,7 +3,7 @@ use crate::{
     config::{Mode, ModeType},
     constants::{
         APPNAME, DEFAULT_LANGUAGE, DEFAULT_TIME_DURATION_LIST, DEFAULT_WORD_COUNT_LIST,
-        MIN_TERM_HEIGHT, MIN_TERM_WIDTH, TYPING_AREA_WIDTH,
+        MIN_TERM_HEIGHT, MIN_TERM_WIDTH,
     },
     menu::MenuItemResult,
     modal::ModalContext,

--- a/src/ui/elements.rs
+++ b/src/ui/elements.rs
@@ -216,16 +216,14 @@ pub fn create_mode_bar(termi: &Termi) -> Vec<TermiElement> {
 
 pub fn create_typing_area<'a>(
     termi: &'a Termi,
-    width: usize,
     scroll_offset: usize,
     visible_line_count: usize,
     word_positions: &[WordPosition],
-) -> (Text<'a>, usize) {
-    let typing_width = width.min(TYPING_AREA_WIDTH as usize);
+) -> Text<'a> {
     let theme = termi.current_theme();
 
     if word_positions.is_empty() {
-        return (Text::raw(""), typing_width);
+        return Text::raw("");
     }
 
     let words: Vec<&str> = termi.words.split_whitespace().collect();
@@ -306,7 +304,7 @@ pub fn create_typing_area<'a>(
     }
 
     let text = Text::from(lines);
-    (text, typing_width)
+    text
 }
 
 pub fn create_command_bar(termi: &Termi) -> Vec<TermiElement> {

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -98,7 +98,7 @@ pub fn create_layout(area: Rect, termi: &Termi) -> TermiLayout {
         .split(top_area);
 
     let header_section = top_chunk[0];
-    let action_bar_section = apply_horizontal_centering(top_chunk[1], TYPING_AREA_WIDTH);
+    let action_bar_section = create_centered_rect_with_max_width(top_chunk[1], TYPING_AREA_WIDTH);
 
     // ==== MIDDLE ====
     let mid_outer_chunk = Layout::default()
@@ -118,8 +118,8 @@ pub fn create_layout(area: Rect, termi: &Termi) -> TermiLayout {
         ])
         .split(mid_outer_chunk);
 
-    let mode_bar_section = apply_horizontal_centering(mid_chunk[0], TYPING_AREA_WIDTH);
-    let typing_area_section = apply_horizontal_centering(mid_chunk[1], TYPING_AREA_WIDTH);
+    let mode_bar_section = create_centered_rect_with_max_width(mid_chunk[0], TYPING_AREA_WIDTH);
+    let typing_area_section = create_centered_rect_with_max_width(mid_chunk[1], TYPING_AREA_WIDTH);
 
     // ==== BOTTOM ====
     let bot_chunks = Layout::default()
@@ -131,8 +131,8 @@ pub fn create_layout(area: Rect, termi: &Termi) -> TermiLayout {
         ])
         .split(bot_area);
 
-    let command_bar_section = apply_horizontal_centering(bot_chunks[0], TYPING_AREA_WIDTH);
-    let footer_section = apply_horizontal_centering(bot_chunks[2], TYPING_AREA_WIDTH);
+    let command_bar_section = create_centered_rect_with_max_width(bot_chunks[0], TYPING_AREA_WIDTH);
+    let footer_section = create_centered_rect_with_max_width(bot_chunks[2], TYPING_AREA_WIDTH);
 
     let section = TermiSection {
         header: header_section,
@@ -146,14 +146,13 @@ pub fn create_layout(area: Rect, termi: &Termi) -> TermiLayout {
     TermiLayout { area, section }
 }
 
-fn apply_horizontal_centering(area: Rect, width_percent: u16) -> Rect {
-    let padding = (100 - width_percent) / 2;
-    Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([
-            Constraint::Percentage(padding),
-            Constraint::Percentage(width_percent),
-            Constraint::Percentage(padding),
-        ])
-        .split(area)[1] // centered chunk
+fn create_centered_rect_with_max_width(area: Rect, max_content_width: u16) -> Rect {
+    let display_width = max_content_width.min(area.width);
+    let padding = area.width.saturating_sub(display_width) / 2;
+    Rect {
+        x: area.x + padding,
+        y: area.y,
+        width: display_width,
+        height: area.height,
+    }
 }

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -147,12 +147,13 @@ pub fn create_layout(area: Rect, termi: &Termi) -> TermiLayout {
 }
 
 fn create_centered_rect_with_max_width(area: Rect, max_content_width: u16) -> Rect {
-    let display_width = max_content_width.min(area.width);
-    let padding = area.width.saturating_sub(display_width) / 2;
-    Rect {
-        x: area.x + padding,
-        y: area.y,
-        width: display_width,
-        height: area.height,
-    }
+    let padding = (100 - max_content_width) / 2;
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage(padding),
+            Constraint::Percentage(max_content_width),
+            Constraint::Percentage(padding),
+        ])
+        .split(area)[1] // centered chunk
 }

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -790,20 +790,45 @@ pub fn render_results_screen(frame: &mut Frame, termi: &mut Termi, area: Rect, i
     let header = format!("{}@{}", username, hostname);
     let separator = "─".repeat(header.chars().count());
 
+    let is_monochromatic = termi.config.monocrhomatic_results;
+
+    let color_succes = if is_monochromatic {
+        theme.highlight()
+    } else {
+        theme.success()
+    };
+    let color_fg = if is_monochromatic {
+        theme.muted()
+    } else {
+        theme.fg()
+    };
+
+    let color_muted = if is_monochromatic {
+        theme.fg()
+    } else {
+        theme.muted()
+    };
+
+    let color_warning = if is_monochromatic {
+        theme.highlight()
+    } else {
+        theme.warning()
+    };
+
     // TODO: improve the coloring of this to match fastfetch. They have the @ in a different color.
     let mut stats_lines = vec![
         Line::from(vec![
-            Span::styled(username, Style::default().fg(theme.success())),
-            Span::styled("@", Style::default().fg(theme.fg())),
-            Span::styled(hostname, Style::default().fg(theme.success())),
+            Span::styled(username, Style::default().fg(color_succes)),
+            Span::styled("@", Style::default().fg(color_fg)),
+            Span::styled(hostname, Style::default().fg(color_succes)),
         ]),
-        Line::from(Span::styled(separator, Style::default().fg(theme.fg()))),
+        Line::from(Span::styled(separator, Style::default().fg(color_fg))),
     ];
 
     let add_stat = |label: &str, value: String| -> Line {
         Line::from(vec![
-            Span::styled(format!("{}: ", label), Style::default().fg(theme.warning())),
-            Span::styled(value, Style::default().fg(theme.fg())),
+            Span::styled(format!("{}: ", label), Style::default().fg(color_warning)),
+            Span::styled(value, Style::default().fg(color_fg)),
         ])
     };
 
@@ -882,7 +907,7 @@ pub fn render_results_screen(frame: &mut Frame, termi: &mut Termi, area: Rect, i
     }
     stats_lines.push(Line::from(color_blocks));
 
-    let art_text = Text::from(ASCII_ART).style(Style::default().fg(theme.warning()));
+    let art_text = Text::from(ASCII_ART).style(Style::default().fg(color_warning));
     let art_height = art_text.height() as u16;
     let art_width = art_text.width() as u16;
 
@@ -961,28 +986,22 @@ pub fn render_results_screen(frame: &mut Frame, termi: &mut Termi, area: Rect, i
     }
 
     let footer_line = Line::from(vec![
-        Span::styled("[N]", Style::default().fg(theme.warning())),
+        Span::styled("[N]", Style::default().fg(color_warning)),
         Span::styled(
             "ew",
-            Style::default()
-                .fg(theme.muted())
-                .add_modifier(Modifier::DIM),
+            Style::default().fg(color_muted).add_modifier(Modifier::DIM),
         ),
         Span::styled(" ", Style::default()),
-        Span::styled("[R]", Style::default().fg(theme.warning())),
+        Span::styled("[R]", Style::default().fg(color_warning)),
         Span::styled(
             "edo",
-            Style::default()
-                .fg(theme.muted())
-                .add_modifier(Modifier::DIM),
+            Style::default().fg(color_muted).add_modifier(Modifier::DIM),
         ),
         Span::styled(" ", Style::default()),
-        Span::styled("[Q]", Style::default().fg(theme.warning())),
+        Span::styled("[Q]", Style::default().fg(color_warning)),
         Span::styled(
             "uit",
-            Style::default()
-                .fg(theme.muted())
-                .add_modifier(Modifier::DIM),
+            Style::default().fg(color_muted).add_modifier(Modifier::DIM),
         ),
     ])
     .alignment(Alignment::Center);

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -962,27 +962,26 @@ pub fn render_results_screen(frame: &mut Frame, termi: &mut Termi, area: Rect, i
         }
     }
 
-    let restart_line = Line::from(vec![
+    let footer_line = Line::from(vec![
+        Span::styled("[N]", Style::default().fg(theme.highlight())),
         Span::styled(
-            "tab",
-            Style::default()
-                .fg(theme.highlight())
-                .add_modifier(Modifier::BOLD),
-        ),
-        Span::styled(
-            " + ",
+            "ew",
             Style::default()
                 .fg(theme.muted())
                 .add_modifier(Modifier::DIM),
         ),
+        Span::styled(" ", Style::default()),
+        Span::styled("[R]", Style::default().fg(theme.highlight())),
         Span::styled(
-            "enter",
+            "edo",
             Style::default()
-                .fg(theme.highlight())
-                .add_modifier(Modifier::BOLD),
+                .fg(theme.muted())
+                .add_modifier(Modifier::DIM),
         ),
+        Span::styled(" ", Style::default()),
+        Span::styled("[Q]", Style::default().fg(theme.highlight())),
         Span::styled(
-            " - restart test",
+            "uit",
             Style::default()
                 .fg(theme.muted())
                 .add_modifier(Modifier::DIM),
@@ -998,7 +997,7 @@ pub fn render_results_screen(frame: &mut Frame, termi: &mut Termi, area: Rect, i
             width: area.width,
             height: restart_height,
         };
-        frame.render_widget(Paragraph::new(restart_line), restart_area);
+        frame.render_widget(Paragraph::new(footer_line), restart_area);
     }
 }
 

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -834,7 +834,8 @@ pub fn render_results_screen(frame: &mut Frame, termi: &mut Termi, area: Rect, i
         Mode::Words { count } => format!("Words ({})", count),
     };
 
-    stats_lines.push(add_stat("OS", format!("termitype {}", VERSION)));
+    stats_lines.push(add_stat("OS", "termitype".to_string()));
+    stats_lines.push(add_stat("Version", VERSION.to_string()));
     stats_lines.push(add_stat("Mode", mode_str));
     stats_lines.push(add_stat(
         "Lang",


### PR DESCRIPTION
This PR also include other fixes like:

- Better message when window is too small (inspired by btop 'Terminal size too small')
- Adds `r` and `n` keybinds for the results screen for `redo test` and `new test`, respectively. This comes with a debounce to avoid typing `r` or `n` as the last character and accidentally starting a new test (does not apply to `tab` + `enter`)
- Makes results mimic neofetch coloring as accurate as possible. Comes with a new flag `--monochromatic-results` to show the results with only two colors using the correct color palette of the currently selected theme.
