### PR TITLE
Add new Options menu

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -58,6 +58,9 @@ pub enum TermiAction {
     TogglePunctuation,
     ToggleNumbers,
     ToggleSymbols,
+    ToggleFPS,
+    ToggleLiveWPM,
+    ToggleMonochromaticResults,
 
     // === Previews ===
     ApplyPreview(PreviewType),
@@ -108,6 +111,7 @@ pub enum MenuContext {
     Help,
     About,
     AsciiArt,
+    Options,
 }
 
 // ============== PREVIEW ==============
@@ -325,6 +329,18 @@ pub fn process_action(action: TermiAction, termi: &mut Termi) {
             termi.config.toggle_symbols();
             termi.menu.sync_toggle_items(&termi.config);
             termi.start()
+        }
+        TermiAction::ToggleFPS => {
+            termi.config.toggle_fps();
+            termi.menu.sync_toggle_items(&termi.config);
+        }
+        TermiAction::ToggleLiveWPM => {
+            termi.config.toggle_live_wpm();
+            termi.menu.sync_toggle_items(&termi.config);
+        }
+        TermiAction::ToggleMonochromaticResults => {
+            termi.config.toggle_monochromatic_results();
+            termi.menu.sync_toggle_items(&termi.config);
         }
         TermiAction::ChangeTheme(name) => {
             termi.config.change_theme(&name);

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -61,6 +61,7 @@ pub enum TermiAction {
     ToggleFPS,
     ToggleLiveWPM,
     ToggleMonochromaticResults,
+    ToggleCursorline,
 
     // === Previews ===
     ApplyPreview(PreviewType),
@@ -340,6 +341,10 @@ pub fn process_action(action: TermiAction, termi: &mut Termi) {
         }
         TermiAction::ToggleMonochromaticResults => {
             termi.config.toggle_monochromatic_results();
+            termi.menu.sync_toggle_items(&termi.config);
+        }
+        TermiAction::ToggleCursorline => {
+            termi.config.toggle_cursorline();
             termi.menu.sync_toggle_items(&termi.config);
         }
         TermiAction::ChangeTheme(name) => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -113,6 +113,10 @@ pub struct Config {
     #[arg(long = "hide-live-wpm")]
     pub hide_live_wpm: bool,
 
+    /// Hide menu cursor line
+    #[arg(long = "hide-cursorline")]
+    pub hide_cursorline: bool,
+
     /// Show results with only two colors
     #[arg(long = "monochromatic-results")]
     pub monocrhomatic_results: bool,
@@ -166,6 +170,7 @@ impl Default for Config {
             version: false,
             show_fps: false,
             hide_live_wpm: false,
+            hide_cursorline: false,
             monocrhomatic_results: false,
             #[cfg(debug_assertions)]
             debug: false,
@@ -291,6 +296,14 @@ impl Config {
                 if let Some(hide_live_wpm) = persistence.get("hide_live_wpm") {
                     let val = matches!(hide_live_wpm, "true");
                     self.set_live_wpm(val)
+                }
+            }
+
+            // Cursorline
+            if !self.hide_cursorline {
+                if let Some(hide_cursorline) = persistence.get("hide_cursorline") {
+                    let val = matches!(hide_cursorline, "true");
+                    self.set_cursorline(val)
                 }
             }
 
@@ -507,6 +520,13 @@ impl Config {
         }
     }
 
+    fn set_cursorline(&mut self, val: bool) {
+        self.hide_cursorline = val;
+        if let Some(persistence) = &mut self.persistent {
+            let _ = persistence.set("hide_cursorline", val.to_string().as_str());
+        }
+    }
+
     /// Toggles the presence of numbers in the test word pool.
     pub fn toggle_numbers(&mut self) {
         let val = !self.use_numbers;
@@ -551,6 +571,14 @@ impl Config {
                 "monocrhomatic_results",
                 self.monocrhomatic_results.to_string().as_str(),
             );
+        }
+    }
+
+    /// Toggles the cursorline display in menus.
+    pub fn toggle_cursorline(&mut self) {
+        self.hide_cursorline = !self.hide_cursorline;
+        if let Some(persistence) = &mut self.persistent {
+            let _ = persistence.set("hide_cursorline", self.hide_cursorline.to_string().as_str());
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -109,6 +109,10 @@ pub struct Config {
     #[arg(long = "show-fps")]
     pub show_fps: bool,
 
+    /// Hides the live WPM progress
+    #[arg(long = "hide-live-wpm")]
+    pub hide_live_wpm: bool,
+
     /// Show results with only two colors
     #[arg(long = "monochromatic-results")]
     pub monocrhomatic_results: bool,
@@ -161,6 +165,7 @@ impl Default for Config {
             list_languages: false,
             version: false,
             show_fps: false,
+            hide_live_wpm: false,
             monocrhomatic_results: false,
             #[cfg(debug_assertions)]
             debug: false,
@@ -219,6 +224,7 @@ impl Config {
                 }
             }
 
+            // Current Mode
             if self.time.is_none() && self.words.is_none() {
                 // Mode and its value
                 let mode_type = persistence
@@ -244,7 +250,7 @@ impl Config {
                 }
             }
 
-            // symbols
+            // Symbols
             if !self.use_symbols {
                 if let Some(use_symbols) = persistence.get("use_symbols") {
                     let val = match use_symbols {
@@ -256,7 +262,7 @@ impl Config {
                 }
             }
 
-            // numbers
+            // Numbers
             if !self.use_numbers {
                 if let Some(use_numbers) = persistence.get("use_numbers") {
                     let val = match use_numbers {
@@ -268,7 +274,7 @@ impl Config {
                 }
             }
 
-            // punctuation
+            // Punctuation
             if !self.use_punctuation {
                 if let Some(use_punctuation) = persistence.get("use_punctuation") {
                     let val = match use_punctuation {
@@ -277,6 +283,14 @@ impl Config {
                         _ => false,
                     };
                     self.set_punctuation(val);
+                }
+            }
+
+            // Live WPM
+            if !self.hide_live_wpm {
+                if let Some(hide_live_wpm) = persistence.get("hide_live_wpm") {
+                    let val = matches!(hide_live_wpm, "true");
+                    self.set_live_wpm(val)
                 }
             }
 
@@ -486,6 +500,13 @@ impl Config {
         }
     }
 
+    fn set_live_wpm(&mut self, val: bool) {
+        self.hide_live_wpm = val;
+        if let Some(persistence) = &mut self.persistent {
+            let _ = persistence.set("hide_live_wpm", val.to_string().as_str());
+        }
+    }
+
     /// Toggles the presence of numbers in the test word pool.
     pub fn toggle_numbers(&mut self) {
         let val = !self.use_numbers;
@@ -505,6 +526,32 @@ impl Config {
         let val = !self.use_symbols;
         self.use_symbols = val;
         self.set_symbols(val);
+    }
+
+    /// Toggles the FPS display.
+    pub fn toggle_fps(&mut self) {
+        self.show_fps = !self.show_fps;
+        if let Some(persistence) = &mut self.persistent {
+            let _ = persistence.set("show_fps", self.show_fps.to_string().as_str());
+        }
+    }
+
+    /// Toggles the live WPM display.
+    pub fn toggle_live_wpm(&mut self) {
+        let val = !self.hide_live_wpm;
+        self.hide_live_wpm = val;
+        self.set_live_wpm(val);
+    }
+
+    /// Toggles the monochromatic results display.
+    pub fn toggle_monochromatic_results(&mut self) {
+        self.monocrhomatic_results = !self.monocrhomatic_results;
+        if let Some(persistence) = &mut self.persistent {
+            let _ = persistence.set(
+                "monocrhomatic_results",
+                self.monocrhomatic_results.to_string().as_str(),
+            );
+        }
     }
 
     /// Chesk if the current terminal has proper color support. Mainly used for themes
@@ -680,9 +727,24 @@ mod tests {
     #[test]
     fn test_config_toggles() {
         let mut config = create_config();
+        assert!(!config.use_numbers);
+        assert!(!config.use_punctuation);
+        assert!(!config.use_symbols);
+
         config.toggle_numbers();
+        assert!(config.use_numbers);
+
         config.toggle_punctuation();
+        assert!(config.use_punctuation);
+
         config.toggle_symbols();
+        assert!(config.use_symbols);
+    }
+
+    #[test]
+    fn test_config_live_wpm() {
+        let config = create_config();
+        assert!(!config.hide_live_wpm) // we default this to false (show live WPM)
     }
 
     #[test]

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -657,16 +657,17 @@ mod tests {
         assert!(menu.is_open());
         config.use_punctuation = true;
         menu.sync_toggle_items(&config);
+        menu.handle_action(TermiAction::MenuOpen(MenuContext::Options), &config);
 
         if let Some(menu_ref) = menu.current_menu() {
             let current_items = menu_ref.items();
             let item = current_items
                 .iter()
-                .find(|i| i.label == "Punctuation")
+                .find(|i| i.label == "Use Punctuation")
                 .unwrap();
             assert_eq!(item.is_active, Some(true));
         } else {
-            panic!("We should have a menu opened by this point")
+            panic!("We should have a menu opened Options by this point")
         }
     }
 

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -426,6 +426,7 @@ impl MenuState {
                             "options/fps" => TermiAction::ToggleFPS,
                             "options/show_live_wpm" => TermiAction::ToggleLiveWPM,
                             "options/monochromatic" => TermiAction::ToggleMonochromaticResults,
+                            "options/show_cursorline" => TermiAction::ToggleCursorline,
                             _ => TermiAction::NoOp,
                         };
                         return Some(act);
@@ -506,6 +507,13 @@ impl MenuState {
                 .find(|i| i.id == "options/show_live_wpm")
             {
                 item.is_active = Some(!config.hide_live_wpm);
+            }
+            if let Some(item) = menu
+                ._items
+                .iter_mut()
+                .find(|i| i.id == "options/show_cursorline")
+            {
+                item.is_active = Some(!config.hide_cursorline);
             }
             if let Some(item) = menu
                 ._items

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -290,6 +290,10 @@ impl MenuState {
         is_menu_context!(self, MenuContext::PickerStyle)
     }
 
+    pub fn is_options_menu(&self) -> bool {
+        is_menu_context!(self, MenuContext::Options)
+    }
+
     pub fn current_menu(&self) -> Option<&Menu> {
         self.stack.last()
     }
@@ -307,6 +311,7 @@ impl MenuState {
                     || self.is_help_menu()
                     || self.is_about_menu()
                     || self.is_ascii_art_menu()
+                    || self.is_options_menu()
                 {
                     self.close();
                 } else {
@@ -415,9 +420,12 @@ impl MenuState {
                     {
                         // TODO: maybe this ids need to be MenuItemId enum
                         let act = match id.as_str() {
-                            "root/punctuation" => TermiAction::TogglePunctuation,
-                            "root/numbers" => TermiAction::ToggleNumbers,
-                            "root/symbols" => TermiAction::ToggleSymbols,
+                            "options/symbols" => TermiAction::ToggleSymbols,
+                            "options/punctuation" => TermiAction::TogglePunctuation,
+                            "options/numbers" => TermiAction::ToggleNumbers,
+                            "options/fps" => TermiAction::ToggleFPS,
+                            "options/show_live_wpm" => TermiAction::ToggleLiveWPM,
+                            "options/monochromatic" => TermiAction::ToggleMonochromaticResults,
                             _ => TermiAction::NoOp,
                         };
                         return Some(act);
@@ -474,14 +482,37 @@ impl MenuState {
     pub fn sync_toggle_items(&mut self, config: &Config) {
         if let Some(menu) = self.stack.last_mut() {
             // TODO: there has to be a better way of doing this
-            if let Some(item) = menu._items.iter_mut().find(|i| i.id == "root/punctuation") {
+            // FIXME: having to iterate throught the items to find every item and match to a toggle is not smart.
+            // Options menu - basically will contain all the toggles of the game
+            if let Some(item) = menu
+                ._items
+                .iter_mut()
+                .find(|i| i.id == "options/punctuation")
+            {
                 item.is_active = Some(config.use_punctuation);
             }
-            if let Some(item) = menu._items.iter_mut().find(|i| i.id == "root/symbols") {
+            if let Some(item) = menu._items.iter_mut().find(|i| i.id == "options/symbols") {
                 item.is_active = Some(config.use_symbols);
             }
-            if let Some(item) = menu._items.iter_mut().find(|i| i.id == "root/numbers") {
+            if let Some(item) = menu._items.iter_mut().find(|i| i.id == "options/numbers") {
                 item.is_active = Some(config.use_numbers);
+            }
+            if let Some(item) = menu._items.iter_mut().find(|i| i.id == "options/fps") {
+                item.is_active = Some(config.show_fps);
+            }
+            if let Some(item) = menu
+                ._items
+                .iter_mut()
+                .find(|i| i.id == "options/show_live_wpm")
+            {
+                item.is_active = Some(!config.hide_live_wpm);
+            }
+            if let Some(item) = menu
+                ._items
+                .iter_mut()
+                .find(|i| i.id == "options/monochromatic")
+            {
+                item.is_active = Some(config.monocrhomatic_results);
             }
         }
     }
@@ -546,7 +577,9 @@ impl MenuState {
                 }
             }
             MenuContext::LineCount => Some(format!("lines/{}", config.visible_lines)),
-            MenuContext::Root | MenuContext::About | MenuContext::Help => None,
+            MenuContext::Root | MenuContext::About | MenuContext::Help | MenuContext::Options => {
+                None
+            }
         };
 
         if let Some(id) = target_id {

--- a/src/menu_builder.rs
+++ b/src/menu_builder.rs
@@ -245,7 +245,7 @@ fn build_options_menu(config: &Config) -> Menu {
         ),
         MenuItem::toggle(
             "options/show_cursorline",
-            "Show Cursorline",
+            "Show Menu Cursorline",
             !config.hide_cursorline,
         ),
         MenuItem::toggle(

--- a/src/menu_builder.rs
+++ b/src/menu_builder.rs
@@ -22,14 +22,13 @@ pub fn build_menu(ctx: MenuContext, config: &Config) -> Menu {
         MenuContext::Help => build_help_menu(),
         MenuContext::About => build_about_menu(),
         MenuContext::AsciiArt => build_ascii_art_menu(),
+        MenuContext::Options => build_options_menu(config),
     }
 }
 
 fn build_root_menu(config: &Config) -> Menu {
     let items = vec![
-        MenuItem::toggle("root/punctuation", "Punctuation", config.use_punctuation),
-        MenuItem::toggle("root/numbers", "Numbers", config.use_numbers),
-        MenuItem::toggle("root/symbols", "Symbols", config.use_symbols),
+        MenuItem::sub_menu("root/options", "Options...", MenuContext::Options),
         MenuItem::sub_menu("root/mode", "Mode...", MenuContext::Mode),
         MenuItem::sub_menu("root/time", "Time...", MenuContext::Time),
         MenuItem::sub_menu("root/words", "Words...", MenuContext::Words),
@@ -222,6 +221,31 @@ fn build_lines_count_menu() -> Menu {
         "Select Visible Lines".to_string(),
         items,
     )
+}
+
+/// Builds the Options menu with all toggleable settings
+fn build_options_menu(config: &Config) -> Menu {
+    let items = vec![
+        MenuItem::toggle("options/symbols", "Use Symbols", config.use_symbols),
+        MenuItem::toggle(
+            "options/punctuation",
+            "Use Punctuation",
+            config.use_punctuation,
+        ),
+        MenuItem::toggle("options/numbers", "Use Numbers", config.use_numbers),
+        MenuItem::toggle("options/fps", "Show FPS", config.show_fps),
+        MenuItem::toggle(
+            "options/show_live_wpm",
+            "Show Live WPM",
+            !config.hide_live_wpm,
+        ),
+        MenuItem::toggle(
+            "options/monochromatic",
+            "Monochromatic Results",
+            config.monocrhomatic_results,
+        ),
+    ];
+    Menu::new(MenuContext::Options, "Options".to_string(), items)
 }
 
 /// Builds the Help menu

--- a/src/menu_builder.rs
+++ b/src/menu_builder.rs
@@ -28,19 +28,23 @@ pub fn build_menu(ctx: MenuContext, config: &Config) -> Menu {
 
 fn build_root_menu(config: &Config) -> Menu {
     let items = vec![
+        // === Configuration Group ===
         MenuItem::sub_menu("root/options", "Options...", MenuContext::Options),
         MenuItem::sub_menu("root/mode", "Mode...", MenuContext::Mode),
         MenuItem::sub_menu("root/time", "Time...", MenuContext::Time),
         MenuItem::sub_menu("root/words", "Words...", MenuContext::Words),
+        // === Appearance Group ===
         MenuItem::sub_menu("root/language", "Language...", MenuContext::Language),
         MenuItem::sub_menu("root/theme", "Theme...", MenuContext::Theme)
             .disabled(!config.term_has_color_support()),
-        MenuItem::sub_menu("root/picker", "Picker...", MenuContext::PickerStyle),
-        MenuItem::sub_menu("root/ascii", "Art...", MenuContext::AsciiArt),
-        MenuItem::sub_menu("root/cursor", "Cursor...", MenuContext::Cursor),
+        MenuItem::sub_menu("root/picker", "Picker Style...", MenuContext::PickerStyle),
+        MenuItem::sub_menu("root/ascii", "ASCII Art...", MenuContext::AsciiArt),
+        MenuItem::sub_menu("root/cursor", "Cursor Style...", MenuContext::Cursor),
         MenuItem::sub_menu("root/lines", "Visible Lines...", MenuContext::LineCount),
+        // === Information Group ===
         MenuItem::sub_menu("root/about", "About...", MenuContext::About),
         MenuItem::sub_menu("root/help", "Help...", MenuContext::Help),
+        // === Action ===
         MenuItem::action("root/quit", "Exit", TermiAction::Quit),
     ];
     Menu::new(MenuContext::Root, "Main Menu".to_string(), items)
@@ -240,6 +244,11 @@ fn build_options_menu(config: &Config) -> Menu {
             !config.hide_live_wpm,
         ),
         MenuItem::toggle(
+            "options/show_cursorline",
+            "Show Cursorline",
+            !config.hide_cursorline,
+        ),
+        MenuItem::toggle(
             "options/monochromatic",
             "Monochromatic Results",
             config.monocrhomatic_results,
@@ -259,22 +268,18 @@ fn build_help_menu() -> Menu {
         "[all] ctrl-z -> Quit (alt)",
         "[all] tab-enter -> Restart Test",
         // === Menu Nav ===
-        "[menu] up -> Navigate Up",
-        "[menu] <down> -> Navigate Down",
-        "[menu] k -> Navigate Up",
-        "[menu] j -> Navigate Down",
-        "[menu] gg-> Home",
-        "[menu] shift-g -> End",
+        "[menu] ↑/k -> Navigate Up",
+        "[menu] ↓/j -> Navigate Down",
+        "[menu] gg -> Go to Top",
+        "[menu] shift-g -> Go to Bottom",
         "[menu] ctrl-u -> Half Page Up",
         "[menu] ctrl-d -> Half Page Down",
-        "[menu] l -> Select Item / Open Submenu",
-        "[menu] h -> Go Back / Close Menu",
-        "[menu] enter -> Select Item / Open Submenu",
-        "[menu] esc -> Go Back / Close Menu",
+        "[menu] l/enter -> Select Item / Open Submenu",
+        "[menu] h/esc -> Go Back / Close Menu",
         "[menu] ctrl-y -> Select Item / Open Submenu",
         "[menu] space -> Toggle Option",
         "[menu] / -> Start Search Mode",
-        // === Menu Serach ===
+        // === Menu Search ===
         "[search] enter -> Confirm Search/Select",
         "[search] esc -> Exit Search mode",
         "[search] ctrl-p -> Navigate Up",

--- a/src/termi.rs
+++ b/src/termi.rs
@@ -161,12 +161,13 @@ pub fn run<B: Backend>(terminal: &mut Terminal<B>, config: &Config) -> anyhow::R
         }
         let now = Instant::now();
 
-        let current_frame_time =
-            if now.duration_since(last_keystroke) < Duration::from_secs(1) || config.show_fps {
-                typing_frame_time
-            } else {
-                idle_frame_time
-            };
+        let current_frame_time = if now.duration_since(last_keystroke) < Duration::from_secs(1)
+            || termi.config.show_fps
+        {
+            typing_frame_time
+        } else {
+            idle_frame_time
+        };
 
         let timeout = current_frame_time
             .checked_sub(last_tick.elapsed())
@@ -239,13 +240,13 @@ pub fn run<B: Backend>(terminal: &mut Terminal<B>, config: &Config) -> anyhow::R
             }
         }
 
-        let fps_to_display = if config.show_fps {
+        let fps_to_display = if termi.config.show_fps {
             Some(current_fps)
         } else {
             None
         };
 
-        if config.show_fps
+        if termi.config.show_fps
             && !needs_redraw
             && now.duration_since(last_fps_update_time) >= fps_update_interval
         {

--- a/src/ui/elements.rs
+++ b/src/ui/elements.rs
@@ -569,83 +569,102 @@ pub fn build_menu_items<'a>(
                 .chain(visible_items.iter().map(|item| {
                     let is_selected = item.id == current_item_id;
 
-                    let item_style = Style::default()
-                        .fg(if item.is_disabled {
-                            theme.muted()
-                        } else if item.is_active.is_some() {
-                            if item.is_active.unwrap() {
-                                theme.highlight()
-                            } else {
-                                theme.muted()
-                            }
-                        } else if is_selected {
-                            theme.selection_fg()
-                        } else {
-                            theme.fg()
-                        })
-                        .bg(if is_selected && !item.is_disabled {
-                            theme.selection_bg()
-                        } else {
-                            theme.bg()
-                        })
-                        .add_modifier(if item.is_active.is_some() && !item.is_active.unwrap() {
-                            Modifier::DIM
-                        } else {
-                            Modifier::empty()
-                        });
-
                     let supports_unicode = theme.supports_unicode();
                     let arrow_symbol = if supports_unicode { "❯ " } else { "> " };
                     let submenu_symbol = if supports_unicode { " →" } else { " >" };
 
+                    // determines if we should apply cursorline background to content spans or not
+                    let should_render_cursorline =
+                        is_selected && !item.is_disabled && !termi.config.hide_cursorline;
+                    let content_bg = if should_render_cursorline {
+                        theme.selection_bg()
+                    } else {
+                        theme.bg()
+                    };
+
                     let mut spans = vec![
-                        Span::styled("  ", Style::default()),
+                        Span::styled("  ", Style::default()), // in-house left padding
                         Span::styled(
                             if is_selected { arrow_symbol } else { "  " },
-                            Style::default().fg(theme.accent()),
+                            Style::default()
+                                .fg(if is_selected && should_render_cursorline {
+                                    // we have cursorline on
+                                    theme.selection_fg()
+                                } else {
+                                    theme.fg()
+                                })
+                                .bg(content_bg),
                         ),
                     ];
 
-                    // if we get `hide_description` this means we are folding the previews
-                    if hide_description {
-                        if let Some(key) = &item.key {
-                            let mut key_span_style = item_style;
-                            if !item.is_disabled {
-                                key_span_style = key_span_style.add_modifier(Modifier::BOLD);
-                                if !is_selected && item.is_active.is_none() {
-                                    key_span_style = key_span_style.fg(theme.accent());
-                                }
-                            } else {
-                                key_span_style = key_span_style.remove_modifier(Modifier::BOLD);
-                            }
-                            spans.push(Span::styled(key.clone(), key_span_style));
+                    if let Some(key_text) = &item.key {
+                        // info items shennanigans (about, help, etc.)
+                        let formatted_key = if hide_description {
+                            key_text.to_string()
                         } else {
-                            spans.push(Span::styled(item.label.clone(), item_style));
-                        }
+                            format!("{:<width$}", key_text, width = max_key_width + 2)
+                        };
+                        spans.push(Span::styled(
+                            formatted_key,
+                            Style::default()
+                                .fg(theme.accent())
+                                .bg(content_bg)
+                                .add_modifier(Modifier::BOLD),
+                        ));
+                        spans.push(Span::styled(
+                            item.label.clone(),
+                            Style::default().fg(theme.fg()).bg(content_bg),
+                        ));
                     } else {
-                        // pad items with <key> <description> structure
-                        if let Some(key) = &item.key {
-                            let key_text = format!("{:<width$}  ", key, width = max_key_width);
-                            spans.push(Span::styled(
-                                key_text,
-                                Style::default()
-                                    .fg(theme.accent())
-                                    .add_modifier(Modifier::BOLD),
-                            ));
-                            spans.push(Span::styled(item.label.clone(), item_style));
+                        let label_style = if is_selected && !should_render_cursorline {
+                            Style::default()
+                                .fg(theme.highlight())
+                                .add_modifier(Modifier::BOLD)
+                        } else if item.is_disabled {
+                            Style::default()
+                                .fg(theme.muted())
+                                .add_modifier(Modifier::DIM)
                         } else {
-                            if max_key_width > 0 {
-                                // +2 for the "  " separator
-                                spans.push(Span::raw(" ".repeat(max_key_width + 2)));
+                            match &item.result {
+                                MenuItemResult::OpenSubMenu(_) => Style::default().fg(theme.fg()),
+                                MenuItemResult::ToggleState => {
+                                    if item.is_active == Some(true) {
+                                        Style::default().fg(theme.success())
+                                    } else {
+                                        Style::default()
+                                            .fg(theme.muted())
+                                            .add_modifier(Modifier::DIM)
+                                    }
+                                }
+                                _ => Style::default().fg(theme.fg()),
                             }
-                            spans.push(Span::styled(item.label.clone(), item_style));
+                        };
+
+                        // toggleable items prefixes
+                        if let Some(is_active) = item.is_active {
+                            if is_active {
+                                spans.push(Span::styled(
+                                    "[✓] ",
+                                    Style::default().fg(theme.success()).bg(content_bg),
+                                ));
+                            } else {
+                                spans.push(Span::styled(
+                                    "[ ] ",
+                                    Style::default()
+                                        .fg(theme.border())
+                                        .bg(content_bg)
+                                        .add_modifier(Modifier::DIM),
+                                ));
+                            }
                         }
+
+                        spans.push(Span::styled(item.label.clone(), label_style.bg(content_bg)));
                     }
 
                     if matches!(item.result, MenuItemResult::OpenSubMenu(_)) {
                         spans.push(Span::styled(
                             submenu_symbol,
-                            Style::default().fg(theme.accent()),
+                            Style::default().fg(theme.accent()).bg(content_bg),
                         ));
                     }
 

--- a/src/ui/elements.rs
+++ b/src/ui/elements.rs
@@ -196,15 +196,17 @@ pub fn create_mode_bar(termi: &Termi) -> Vec<TermiElement> {
                 }
             };
             let wpm = format!(" {:>3.0} wpm", termi.tracker.wpm);
-            let spans = vec![
-                Span::styled(info, Style::default().fg(theme.highlight())),
-                Span::styled(
+            let mut spans = vec![Span::styled(info, Style::default().fg(theme.highlight()))];
+
+            // the live wpm is an option toggleable by the user
+            if !termi.config.hide_live_wpm {
+                spans.push(Span::styled(
                     wpm,
                     Style::default()
                         .fg(theme.muted())
                         .add_modifier(Modifier::DIM),
-                ),
-            ];
+                ));
+            }
             let line = Line::from(spans);
             let text = Text::from(line);
             TermiElement::new(text, false, None)


### PR DESCRIPTION
The new options menu will contain all the toggleable
options of the app.

This PR includes two new type of toggle able options:

- `--hide-live-wpm`  -> hides the live WPM counter on the test 
- `--hide-cursorline` -> hides the menu cursorline


Closes: #70