### PR TITLE
fix: let the OS handle character composition

### DIFF
--- a/src/ui/utils.rs
+++ b/src/ui/utils.rs
@@ -83,13 +83,20 @@ fn _calculate_positions(text: &str, available_width: usize) -> Vec<WordPosition>
 
     let words: Vec<&str> = text.split_whitespace().collect();
     let mut positions = Vec::with_capacity(words.len());
+    let text_chars: Vec<char> = text.chars().collect();
     let mut char_index = 0;
     let mut line = 0;
     let mut col = 0;
 
     for (word_idx, word) in words.iter().enumerate() {
-        // start position of the original text
-        while char_index < text.len() && !text[char_index..].starts_with(word) {
+        // start position of the word in char indexes
+        let word_chars: Vec<char> = word.chars().collect();
+        while char_index < text_chars.len() {
+            if char_index + word_chars.len() <= text_chars.len()
+                && text_chars[char_index..char_index + word_chars.len()] == word_chars
+            {
+                break;
+            }
             char_index += 1;
         }
 
@@ -107,12 +114,12 @@ fn _calculate_positions(text: &str, available_width: usize) -> Vec<WordPosition>
             col,
         });
 
-        char_index += word.len();
+        char_index += word_len;
         col += word_len;
 
         if word_idx < words.len() - 1 && col < available_width {
             col += 1;
-            char_index += 1;
+            char_index += 1; // skip the character space
         }
     }
 


### PR DESCRIPTION
This PR removes the not so smart `compose_accent` function that was in charge of composing `alt+e` + `<char>` into an accented <char> . This was not smart and only handled Spanish accents. This required an additional `pending_accent` field in the `InputHandler` struct which we no longer need.

Now, we let the OS handle the composition through `crossterm`. While developing this a couple of ui sync issues were found caused by us doing Byte indexing rather than character indexing.

The most simplest reproduction was using `termitype --w "sí prueba"`
And then typing:

- `s` -> `s` (correct)
- `alt+e` -> NoOp
- `e` -> `í` (correct)
- `<space>` (correct)
- `p` -> nothing happens


New set of test were added for the ui syncing and styling logic